### PR TITLE
Move HTML prototype to Mustache and add table display

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -27,7 +27,8 @@
             "extensions": [
                 "ms-azuretools.vscode-docker",
                 "angular.ng-template",
-                "golang.go"
+                "golang.go",
+                "imgildev.vscode-mustache-snippets"
            ]
         }
     },

--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM fedora:39
 
 RUN dnf upgrade -y --refresh && \
-    dnf install -y nodejs nodejs-npm ripgrep eza fd-find && \
+    dnf install -y nodejs nodejs-npm ripgrep eza fd-find rubygem-mustache python3 python3-dateutil && \
     dnf clean all && \
     npm install -g @angular/cli

--- a/html-prototype/data.yaml
+++ b/html-prototype/data.yaml
@@ -1,0 +1,3660 @@
+---
+apis: [
+  {
+    name: API 1,
+    status: fine,
+    status-text: operational,
+    uptime: 1.28,
+    days: [
+      {
+        date: 12.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 20.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 20.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 21.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 26.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 26.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 27.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 29.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 29.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 30.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 31.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 31.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 31.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 01.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 03.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 03.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 03.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 04.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 08.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 08.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 08.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 08.11.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 09.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 12.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 12.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 12.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 13.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 13.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 13.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 13.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 14.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 18.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 18.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 18.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 19.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 28.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 28.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 28.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 29.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 01.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 01.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 01.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 02.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 02.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 02.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 02.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 03.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 07.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 07.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 07.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 08.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 15.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 15.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 16.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 19.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 19.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 19.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 20.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.01.2024,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 1,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 01.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 01.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 01.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 02.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 02.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 02.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 02.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 03.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 04.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 04.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 04.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 05.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.01.2024,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 07.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 07.01.2024 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 08.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 09.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 09.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 09.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 10.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+    ]
+  },
+  {
+    name: API 2,
+    status: broken,
+    status-text: broken,
+    uptime: 1.20,
+    days: [
+      {
+        date: 12.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 15.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 15.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 15.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 16.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 17.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 17.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 18.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 22.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 22.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 22.10.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 22.10.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 23.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 26.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 26.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 26.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 27.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 07.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 07.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 07.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 08.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 08.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 08.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 08.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 09.11.2023,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 09.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 09.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 09.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 10.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 11.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 11.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 12.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 17.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 17.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 17.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 18.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 18.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 18.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 19.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 21.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 21.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 21.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 22.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 26.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 26.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 26.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 26.11.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 27.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 27.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 27.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 28.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 01.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 01.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 01.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 02.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.12.2023,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 03.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 03.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 03.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 04.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 08.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 08.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 08.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 08.12.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 08.12.2023 15:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 08.12.2023 17:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 09.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 09.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 09.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 09.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 10.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 17.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 17.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 17.12.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 17.12.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 18.12.2023,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 18.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 18.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 18.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 19.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 19.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 19.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 19.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 20.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 22.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 22.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 22.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 23.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 23.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 23.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 23.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 24.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 27.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 27.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 27.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 28.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 31.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 31.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 31.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 01.01.2024,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 01.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 01.01.2024 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 02.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 06.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 06.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 06.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 07.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.01.2024,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 10.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 10.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 10.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+    ]
+  },
+  {
+    name: API 3,
+    status: fine,
+    status-text: operational,
+    uptime: 1.28,
+    days: [
+      {
+        date: 12.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 18.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 18.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 18.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 19.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.10.2023,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 3,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 20.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 20.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 20.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 21.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 27.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 27.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 28.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 28.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 28.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 29.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.11.2023,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 3,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 03.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 03.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 03.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 04.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 04.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 04.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 04.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 05.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 05.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 05.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 05.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 06.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 13.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 13.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 14.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 18.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 18.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 18.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 19.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 19.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 19.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 19.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 19.11.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 20.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 20.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 20.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 20.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 21.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 25.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 25.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 25.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 26.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 28.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 28.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 29.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 30.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 30.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 30.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 01.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.12.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.12.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 05.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 16.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 16.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 16.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 17.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 17.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 17.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 17.12.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 17.12.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 18.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 18.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 18.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 19.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 07.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 07.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 07.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 07.01.2024 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 07.01.2024 15:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 07.01.2024 17:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 08.01.2024,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 08.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 08.01.2024 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 09.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+    ]
+  },
+]
+---
+

--- a/html-prototype/generate-data.py
+++ b/html-prototype/generate-data.py
@@ -1,0 +1,200 @@
+from datetime import date, datetime, timedelta
+from dateutil.rrule import rrule, DAILY
+
+import copy
+import random
+
+PRELUDE = """---
+apis: ["""
+
+END = """]
+---
+"""
+
+APIS = ["API 1", "API 2", "API 3"]
+
+DAY_STATUS = ["fine", "limited", "broken", "maintenance"]
+DAY_STATUS_WEIGHTS = [24, 4, 1, 2]
+
+STATUS_TEXTS = {
+    "fine": "operational",
+    "limited": "limited",
+    "broken": "broken",
+    "maintenance": "maintenance"
+}
+
+class DayData:
+    
+    def __init__(self, date):
+        self.date = date
+        self.status = "fine"
+        self.status_text = "operational"
+        self.incidents = []
+
+class Incident:
+
+    def __init__(self, id, title, updates, resolved=False):
+        self.id = id
+        self.title = title
+        self.updates = updates
+        self.resolved = resolved
+        self.date = None
+        self.api = None
+
+    def add_update(self, update):
+        self.updates.append(update)
+        if update.resolves:
+            self.resolved = True
+    
+    def add_date(self, date, additional_hours=0):
+        self.date = date
+        current_time = date + timedelta(hours=6 + additional_hours, minutes=16, seconds=44)
+        delta = timedelta(hours=2, minutes=13, seconds=23)
+        for update in self.updates:
+            update.datetime = current_time
+            current_time = current_time + delta
+
+class IncidentUpdate:
+
+    def __init__(self, title, text, resolves=False):
+        self.title = title
+        self.text = text
+        self.resolves = resolves
+        self.datetime = None
+
+INCIDENTS = {
+    "maintenance": Incident(
+        0,
+        "Scheduled Maintenance",
+        [
+            IncidentUpdate(
+                "Done",
+                "Finished maintenance session. Service is back up.",
+                resolves=True
+            ),
+            IncidentUpdate(
+                "Started",
+                "Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.",
+            ),
+        ]
+    ),
+    "limited": Incident(
+        1,
+        "Sporadic erroneous rate limiting",
+        [
+            IncidentUpdate(
+                "Resolved", 
+                "We have corrected the faulty rate limiting configuration.",
+                resolves=True
+            ),
+            IncidentUpdate(
+                "Investigating",
+                "Our internal monitoring has confirmed these reports."
+            ),
+            IncidentUpdate(
+                "Notified",
+                "We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota."
+            )
+        ]
+    ),
+    "broken": Incident(
+        2,
+        "Service unreachable",
+        [
+            IncidentUpdate(
+                "Identified", 
+                "We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.",
+                resolves=True
+            ),
+            IncidentUpdate(
+                "Investigating",
+                "We have determined that the service itself is unreachable. The server running it seems fine."
+            ),
+            IncidentUpdate(
+                "Notified",
+                "We have received an automated warning about the service."
+            )
+        ]
+    )
+}
+
+RESOLVING_UPDATES_MAINTENANCE = [
+    IncidentUpdate(
+        "Started",
+        "Started the scheduled maintenance session. Return to operational state is expected in roughly two hours."
+    )
+]
+
+def w(file, text):
+    file.write(text + "\n")
+
+def get_incident(api, day, additional_hours=0):
+    incident = copy.deepcopy(INCIDENTS[day.status])
+    incident.api = api
+    incident.add_date(day.date, additional_hours)
+    return incident
+
+if __name__ == "__main__":
+    end = date.today()
+    start = end - timedelta(days=90)
+    print(f"Generating data for period {start} to {end}")
+    with open("generated.yaml", "w") as f:
+        w(f, PRELUDE)
+        for api in APIS:
+            w(f, "  {")
+            w(f, f"    name: {api},")
+            days_limited = 0
+            days_broken = 0
+            days_maintenance = 0
+            day_data = []
+            for dt in rrule(DAILY, dtstart=start, until=end):
+                day = DayData(dt)
+                day.status = random.choices(DAY_STATUS, DAY_STATUS_WEIGHTS)[0]
+                day.status_text = STATUS_TEXTS[day.status]
+                if day.status == "limited":
+                    days_limited = days_limited + 1
+                if day.status == "broken":
+                    days_broken = days_broken + 1
+                if day.status == "maintenance":
+                    days_maintenance = days_maintenance + 1
+                if day.status != "fine":
+                    day.incidents.append(get_incident(api, day))
+                    if random.randrange(10) > 8:
+                        day.incidents.append(get_incident(api, day, 7))
+                day_data.append(day)
+            days_total = len(day_data)
+            days_fine = days_total - days_limited - days_broken - days_maintenance
+            uptime = (days_total - (days_limited + days_broken + days_maintenance)) / days_total
+            status = day_data[-1].status
+            status_text = STATUS_TEXTS[status]
+            w(f, f"    status: {status},")
+            w(f, f"    status-text: {status_text},")
+            w(f, f"    uptime: {uptime + 0.5:.2f},")
+            w(f, f"    days: [")
+            for day in day_data:
+                w(f, "      {")
+                w(f, f"        date: {day.date:%d.%m.%Y},")
+                w(f, f"        status: {day.status},")
+                w(f, f"        status-text: {day.status_text},")
+                w(f,  "        incidents: [")
+                for incident in day.incidents:
+                    w(f,  "          {")
+                    w(f, f"            id: {incident.id},")
+                    w(f, f"            title: {incident.title},")
+                    w(f, f"            api: {api},")
+                    w(f, f"            updates: [")
+                    for update in incident.updates:
+                        w(f,  "              {")
+                        w(f, f"                title: {update.title},")
+                        w(f, f"                text: {update.text},")
+                        w(f, f"                datetime: {update.datetime:%d.%m.%Y %H:%M:%S %Z},")
+                        w(f, f"                resolves: {update.resolves}")
+                        w(f,  "              },")    
+                    w(f, f"            ],")
+                    w(f,  "          },")
+                w(f,  "        ]")
+                w(f,  "      },")
+            w(f, "    ]")
+            w(f, "  },")
+        
+        w(f, END)

--- a/html-prototype/index.html
+++ b/html-prototype/index.html
@@ -21,2935 +21,4623 @@
         </div>
         <div class="status-bar status-maintenance">
             <h4>Maintenance Scheduled</h4>
-            A maintenance session for all services has been scheduled for November 20th, 2023 from 10:00 to 12:00.
+            A maintenance session for all services has been scheduled for January 20th, 2024 from 10:00 to 12:00.
         </div>
         <section class="about">
             <h1>About</h1>
             <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
         </section>
-        <section>
-            <article class="api-list-entry list-entry-first">
-                <div class="api-titlebar">
-                    <h4>API 1</h4>
-                    <div class="status-bar status-fine">operational</div>
-                </div>
-                <div class="api-daily-status">
-                    <div class="day-status-box status-maintenance">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-maintenance">maintenance</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-broken">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-broken">broken</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-limited">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-limited">limited</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-maintenance">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-maintenance">maintenance</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-
-                </div>
-                <div class="api-textbar">
-                    <span>90 days ago</span>
-                    <span>98.13% up time</span>
-                    <span>today</span>
-                </div>
-            </article>
-            <article class="api-list-entry">
-                <div class="api-titlebar">
-                    <h4>API 2</h4>
-                    <div class="status-bar status-limited">limited</div>
-                </div>
-                <div class="api-daily-status">
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-limited">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-limited">limited</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-maintenance">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-maintenance">maintenance</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-limited">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-limited">limited</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="api-textbar">
-                    <span>90 days ago</span>
-                    <span>99.54% up time</span>
-                    <span>today</span>
-                </div>
-            </article>
-            <article class="api-list-entry list-entry-last">
-                <div class="api-titlebar">
-                    <h4>API 3</h4>
-                    <div class="status-bar status-broken">broken</div>
-                </div>
-                <div class="api-daily-status">
-                    <div class="day-status-box status-limited">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-limited">limited</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-fine">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-fine">operational</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-broken">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-broken">broken</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                    </div>
-                    <div class="day-status-box status-broken">
-                        <div class="tooltip-wrap">
-                            <div class="tooltip-content">
-                                <div class="tooltip-title">
-                                    <span><h5>17.11.2023</h5></span>
-                                    <div class="status-bar status-broken">broken</div>
-                                </div>
-                                <hr>
-                                No incidents
-                            </div>
-                        </div>
-                        <a href="./incident.html"></a>
-                    </div>
-                </div>
-                <div class="api-textbar">
-                    <span>90 days ago</span>
-                    <span>95.66% up time</span>
-                    <span>today</span>
-                </div>
-            </article>
-        </section>
+        <section id="api-list">
+                <article class="api-list-entry">
+                    <div class="api-titlebar">
+                        <h4>API 1</h4>
+                        <div class="status-bar status-fine">operational</div>
+                    </div>
+                    <div class="api-daily-status">
+                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>31.10.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>31.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.01.2024</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.01.2024</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                    </div>
+                    <div class="api-textbar">
+                        <span>90 days ago</span>
+                        <span>1.28% up time</span>
+                        <span>today</span>
+                    </div>
+                </article>                <article class="api-list-entry">
+                    <div class="api-titlebar">
+                        <h4>API 2</h4>
+                        <div class="status-bar status-broken">broken</div>
+                    </div>
+                    <div class="api-daily-status">
+                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.10.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.10.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>31.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.11.2023</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.12.2023</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.12.2023</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>31.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.01.2024</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.01.2024</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                    </div>
+                    <div class="api-textbar">
+                        <span>90 days ago</span>
+                        <span>1.2% up time</span>
+                        <span>today</span>
+                    </div>
+                </article>                <article class="api-list-entry">
+                    <div class="api-titlebar">
+                        <h4>API 3</h4>
+                        <div class="status-bar status-fine">operational</div>
+                    </div>
+                    <div class="api-daily-status">
+                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.10.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.10.2023</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.10.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>31.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-broken">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.11.2023</h5></span>
+                                            <div class="status-bar status-broken">broken</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>17.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>20.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>21.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>23.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>24.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>25.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>26.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>27.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>30.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>31.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>01.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-limited">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>07.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>08.01.2024</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                    </div>
+                    <div class="api-textbar">
+                        <span>90 days ago</span>
+                        <span>1.28% up time</span>
+                        <span>today</span>
+                    </div>
+                </article>        </section>
+        <section id="api-table" class="hidden">
+                <article>
+                    <div class="api-table-title">
+                        <h4>API 1</h4>
+                        <span class="status-bar status-fine">operational</span>
+                    </div>
+                    <table class="api-table">
+                        <thead>
+                            <tr>
+                                <th>Day</th>
+                                <th>Status</th>
+                                <th>Incidents</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                                <tr>
+                                    <th>12.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>31.10.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>11.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>12.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>11.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>12.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>31.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.01.2024</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.01.2024</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                            
+                        </tbody>
+                    </table>
+                </article>                <article>
+                    <div class="api-table-title">
+                        <h4>API 2</h4>
+                        <span class="status-bar status-broken">broken</span>
+                    </div>
+                    <table class="api-table">
+                        <thead>
+                            <tr>
+                                <th>Day</th>
+                                <th>Status</th>
+                                <th>Incidents</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                                <tr>
+                                    <th>12.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.10.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.10.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>31.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.11.2023</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>11.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>12.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.12.2023</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>11.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>12.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.12.2023</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>31.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.01.2024</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.01.2024</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                            
+                        </tbody>
+                    </table>
+                </article>                <article>
+                    <div class="api-table-title">
+                        <h4>API 3</h4>
+                        <span class="status-bar status-fine">operational</span>
+                    </div>
+                    <table class="api-table">
+                        <thead>
+                            <tr>
+                                <th>Day</th>
+                                <th>Status</th>
+                                <th>Incidents</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                                <tr>
+                                    <th>12.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.10.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.10.2023</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>31.10.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.11.2023</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>11.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>12.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.11.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>11.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>12.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>13.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>14.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>15.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>16.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>17.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>18.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>19.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>20.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>21.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>22.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>23.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>24.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>25.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>26.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>27.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>28.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>29.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>30.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>31.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>01.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>02.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>03.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>04.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>05.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>06.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>07.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>08.01.2024</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>09.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>10.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                            
+                        </tbody>
+                    </table>
+                </article>        </section>
         <section class="incident-log">
             <h1>Incident Log</h1>
             <section>
@@ -3031,6 +4719,7 @@
         <div id="accessibility-options">
             <h5>Accessibility options:</h5>
             <input id="colorBlindMode" type="checkbox" onclick="switchColorMode()"></input><label for="colorBlindMode">Colors for colorblind</label>
+            <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
             <input id="increasedTextSizeMode" type="checkbox" onclick="switchTextSize()"></input><label for="increasedTextSizeMode">Increased text size</label>
         </div>
         <div id="other-links">

--- a/html-prototype/make-prototype.sh
+++ b/html-prototype/make-prototype.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+if ! command -v mustache &> /dev/null
+then
+    echo "this script needs an install of the mustache template system"
+    exit 1
+fi
+
+cd templates
+mustache ../data.yaml page.mustache > ../index.html
+cd ..
+
+echo "Generated index.html using mustache"

--- a/html-prototype/statuspage.js
+++ b/html-prototype/statuspage.js
@@ -1,5 +1,6 @@
 
 const CB_COLORBLIND = "colorBlindMode";
+const CB_TABLE = "tableMode";
 const CB_INCREASED_TEXT = "increasedTextSizeMode";
 
 let themeColors = {}
@@ -27,6 +28,10 @@ function init() {
     if (document.cookie.match("AccessibilityIncreasedText=true")) {
         document.getElementById(CB_INCREASED_TEXT).checked = true;
         switchTextSize();
+    }
+    if (document.cookie.match("AccessibilityUseTable=true")) {
+        document.getElementById(CB_TABLE).checked = true;
+        switchApiDisplay();
     }
 }
 
@@ -61,5 +66,20 @@ function switchTextSize() {
         let r = document.querySelector(":root");
         r.style.setProperty("--default-text-size", TextSizes.Default);
         document.cookie = "AccessibilityIncreasedText=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+    }
+}
+
+function switchApiDisplay() {
+    let checkbox = document.getElementById(CB_TABLE);
+    let list = document.getElementById("api-list");
+    let table = document.getElementById("api-table");
+    if (checkbox.checked) {
+        list.classList.add("hidden");
+        table.classList.remove("hidden");
+        document.cookie = "AccessibilityUseTable=true";
+    } else {
+        table.classList.add("hidden");
+        list.classList.remove("hidden");
+        document.cookie = "AccessibilityUseTable=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
     }
 }

--- a/html-prototype/styles.css
+++ b/html-prototype/styles.css
@@ -171,6 +171,13 @@ h5 {
     padding: 0;
 }
 
+h6 {
+    font-size: 1.0rem;
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+
 hr {
     color: var(--line-color);
     border-width: 1px;
@@ -195,6 +202,7 @@ header {
 }
 
 footer {
+    margin-top: 1rem;
     border-top: 1px var(--line-color) solid;
     width: 100%;   
 }
@@ -322,20 +330,15 @@ footer div input {
     padding: .5rem 1rem;
 }
 
-.list-entry-first {
+.api-list-entry:first-of-type {
     border-top-left-radius: var(--list-border-radius);
     border-top-right-radius: var(--list-border-radius);
 }
 
-.list-entry-last {
+.api-list-entry:last-of-type {
     border-bottom: 1px var(--border-color) solid;
     border-bottom-left-radius: var(--list-border-radius);
     border-bottom-right-radius: var(--list-border-radius);
-}
-
-.list-entry-only {
-    border: 1px var(--border-color) solid;
-    border-radius: var(--list-border-radius);
 }
 
 .api-titlebar {
@@ -385,6 +388,44 @@ footer div input {
     justify-content: space-between;
     color: var(--faint-text-color);
     font-size: .75rem;
+}
+
+.api-table-title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 5px 0 5px 0;
+    align-items: center;
+}
+
+.api-table-title h4 {
+    font-size: 1.25rem;
+}
+
+#api-table article {
+    margin: 1rem;
+}
+
+table {
+    border-collapse: collapse;
+    border: 2px solid var(--line-color);
+}
+
+table.api-table {
+    width: 100%;
+}
+
+td, th {
+    border: 1px solid var(--line-color);
+    padding: 0.5rem;
+}
+
+.api-table .status-bar {
+    margin: 0;
+    height: 1rem;
+    padding: .25rem .75rem;
+    align-self: center;
+    font-size: .9rem;
 }
 
 .tooltip-wrap {
@@ -485,4 +526,8 @@ footer div input {
     padding: .75rem;
     border-radius: var(--bar-border-radius);
     font-weight: bold;
+}
+
+.hidden {
+    display: none;
 }

--- a/html-prototype/templates/api-list.mustache
+++ b/html-prototype/templates/api-list.mustache
@@ -1,0 +1,16 @@
+<article class="api-list-entry">
+    <div class="api-titlebar">
+        <h4>{{ name }}</h4>
+        <div class="status-bar status-{{ status }}">{{ status-text }}</div>
+    </div>
+    <div class="api-daily-status">
+        {{# days }}
+            {{> api-status-box }}
+        {{/ days }}
+    </div>
+    <div class="api-textbar">
+        <span>90 days ago</span>
+        <span>{{ uptime }}% up time</span>
+        <span>today</span>
+    </div>
+</article>

--- a/html-prototype/templates/api-status-box.mustache
+++ b/html-prototype/templates/api-status-box.mustache
@@ -1,0 +1,14 @@
+<div class="day-status-box status-{{ status }}">
+    <div class="tooltip-wrap">
+        <div class="tooltip-content">
+            <div class="tooltip-title">
+                <span><h5>{{ date }}</h5></span>
+                <div class="status-bar status-{{ status }}">{{ status-text }}</div>
+            </div>
+            <hr>
+            {{#incidents}}
+                <h6>{{ title }}</h6>
+            {{/incidents}}
+        </div>
+    </div>
+</div>

--- a/html-prototype/templates/api-table.mustache
+++ b/html-prototype/templates/api-table.mustache
@@ -1,0 +1,29 @@
+<article>
+    <div class="api-table-title">
+        <h4>{{ name }}</h4>
+        <span class="status-bar status-{{ status }}">{{ status-text }}</span>
+    </div>
+    <table class="api-table">
+        <thead>
+            <tr>
+                <th>Day</th>
+                <th>Status</th>
+                <th>Incidents</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{# days }}
+                <tr>
+                    <th>{{ date }}</th>
+                    <td><span class="status-bar status-{{ status }}">{{ status-text }}</span></td>
+                    <td>
+                        {{# incidents }}
+                            <a style="display:block;" href="./incident.html">{{ title }}</a>
+                        {{/ incidents }}
+                    </td>
+                </tr>
+            {{/ days }}
+            
+        </tbody>
+    </table>
+</article>

--- a/html-prototype/templates/page.mustache
+++ b/html-prototype/templates/page.mustache
@@ -1,0 +1,131 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>SCS Statuspage</title>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css2?family=Lato">
+    <link rel="stylesheet" type="text/css" href="styles.css">
+    <script type="application/javascript" src="statuspage.js"></script>
+</head>
+
+<body onload="init()">
+    <header>
+        <img alt="" title="SCS Project" src="assets/scs-logo.svg">
+        <button type="button" class="subscribe-btn">Subscribe to Updates</button>
+    </header>
+    <main>
+        <div class="status-bar status-fine">
+            <h4 style="display:none;">Overall Status</h4>
+            All Systems Operational
+        </div>
+        <div class="status-bar status-maintenance">
+            <h4>Maintenance Scheduled</h4>
+            A maintenance session for all services has been scheduled for January 20th, 2024 from 10:00 to 12:00.
+        </div>
+        <section class="about">
+            <h1>About</h1>
+            <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+        </section>
+        <section id="api-list">
+            {{# apis }}
+                {{> api-list }}
+            {{/ apis }}
+        </section>
+        <section id="api-table" class="hidden">
+            {{# apis }}
+                {{> api-table }}
+            {{/ apis }}
+        </section>
+        <section class="incident-log">
+            <h1>Incident Log</h1>
+            <section>
+                <h2>Ongoing Incidents</h2>
+                <article>
+                    <h3>17.11.2023</h3>
+                    <article class="incident">
+                        <h4><!--<span class="incident-status status-broken">ongoing</span>--><a class="text-broken" href="./incident.html">API 3 - Service unreachable</a></h4>
+                        <p class="incident-start-date">since 16.11.2023</p>
+                        <section class="incident-update">
+                            <h5>Identified</h5>
+                            <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                            <p class="incident-update-time">17.11.2023, 15:07 UTC</p>
+                        </section>
+                        <section class="incident-update">
+                            <h5>Investigating</h5>
+                            <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                            <p class="incident-update-time">16.11.2023, 17:22 UTC</p>
+                        </section>
+                        <section class="incident-update">
+                            <h5>Notified</h5>
+                            <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                            <p class="incident-update-time">16.11.2023, 14:41 UTC</p>
+                        </section>
+                    </article>
+                </article>
+            </section>
+            <section>
+                <h2>Past Incidents</h2>
+                <article>
+                    <h3>17.11.2023</h3>
+                    <article class="incident">
+                        <h4><!--<span class="incident-status status-fine">resolved</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                        <div class="incident-update">
+                            <h5>Resolved</h5>
+                            <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                            <p class="incident-update-time">17.11.2023, 18:04 UTC</p>
+                        </div>
+                        <div class="incident-update">
+                            <h5>Investigating</h5>
+                            <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                            <p class="incident-update-time">17.11.2023, 16:33 UTC</p>
+                        </div>
+                        <div class="incident-update">
+                            <h5>Notified</h5>
+                            <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.</span>
+                            <p class="incident-update-time">17.11.2023, 16:02 UTC</p>
+                        </div>
+                    </article>
+                </article>
+                <article>
+                    <h3>16.11.2023</h3>
+                    <p>1 incident ongoing</p>
+                </article>
+                <article>
+                    <h3>15.11.2023</h3>
+                    <p>no incidents occured</p>
+                </article>
+                <article>
+                    <h3>14.11.2023</h3>
+                    <article class="incident">
+                        <h4 class="text-maintenance"><!--<span class="incident-status status-fine">resolved</span>--><a class="text-maintenance" href="./incident.html">API 1 - Scheduled Maintenance</a></h4>
+                        <div class="incident-update">
+                            <h5>Done</h5>
+                            <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                            <p class="incident-update-time">14.11.2023, 11:45 UTC</p>
+                        </div>
+                        <div class="incident-update">
+                            <h5>Started</h5>
+                            <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                            <p class="incident-update-time">14.11.2023, 10:00 UTC</p>
+                        </div>
+                    </article>
+                </article>
+            </section>
+        </section>
+    </main>
+    <footer>
+        <div id="accessibility-options">
+            <h5>Accessibility options:</h5>
+            <input id="colorBlindMode" type="checkbox" onclick="switchColorMode()"></input><label for="colorBlindMode">Colors for colorblind</label>
+            <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
+            <input id="increasedTextSizeMode" type="checkbox" onclick="switchTextSize()"></input><label for="increasedTextSizeMode">Increased text size</label>
+        </div>
+        <div id="other-links">
+            <a href="./imprint.html">Imprint</a>
+            <a href="#">Login</a>
+            <a href="./cookies.html">Cookie Policy</a>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
The HTML prototype is now generated using the Mustache template system.

Additionally, this adds a different view mode, wherein tables are used for the last 90 days of daily statuses instead of the block display.