### PR TITLE
Add table filtering and past incident log to HTML prototype templates

### DIFF
--- a/html-prototype/data.yaml
+++ b/html-prototype/data.yaml
@@ -4,73 +4,38 @@ apis: [
     name: API 1,
     status: fine,
     status-text: operational,
-    uptime: 89,
+    uptime: 82,
     days: [
       {
-        date: 13.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 14.10.2023,
+        date: 18.10.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 0,
             title: Sporadic erroneous rate limiting,
             api: API 1,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 14.10.2023 06:16:44 ,
+                datetime: 18.10.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 14.10.2023 08:30:07 ,
+                datetime: 18.10.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 14.10.2023 10:43:30 ,
+                datetime: 18.10.2023 10:43:30 ,
                 resolves: False
               },
             ],
           },
-        ]
-      },
-      {
-        date: 15.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 17.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 18.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
         ]
       },
       {
@@ -110,9 +75,34 @@ apis: [
       },
       {
         date: 24.10.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 24.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 24.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 24.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -152,9 +142,34 @@ apis: [
       },
       {
         date: 30.10.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 1,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 30.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 30.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 30.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -173,9 +188,34 @@ apis: [
       },
       {
         date: 02.11.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 3,
+            title: Service unreachable,
+            api: API 1,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 02.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 02.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 02.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -208,9 +248,28 @@ apis: [
       },
       {
         date: 07.11.2023,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 4,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 07.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 07.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -264,9 +323,34 @@ apis: [
       },
       {
         date: 15.11.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 5,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 15.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 15.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 15.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -285,75 +369,37 @@ apis: [
       },
       {
         date: 18.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.11.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 6,
             title: Sporadic erroneous rate limiting,
             api: API 1,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 18.11.2023 06:16:44 ,
+                datetime: 19.11.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 18.11.2023 08:30:07 ,
+                datetime: 19.11.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 18.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 19.11.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 19.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 19.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 19.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 19.11.2023 15:30:07 ,
+                datetime: 19.11.2023 10:43:30 ,
                 resolves: False
               },
             ],
@@ -362,9 +408,59 @@ apis: [
       },
       {
         date: 20.11.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 7,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 20.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 20.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 20.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 8,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 20.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 20.11.2023 15:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 20.11.2023 17:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -411,29 +507,29 @@ apis: [
       },
       {
         date: 27.11.2023,
-        status: broken,
-        status-text: broken,
+        status: limited,
+        status-text: limited,
         incidents: [
           {
-            id: 2,
-            title: Service unreachable,
+            id: 9,
+            title: Sporadic erroneous rate limiting,
             api: API 1,
             updates: [
               {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
                 datetime: 27.11.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                text: Our internal monitoring has confirmed these reports.,
                 datetime: 27.11.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
-                text: We have received an automated warning about the service.,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
                 datetime: 27.11.2023 10:43:30 ,
                 resolves: False
               },
@@ -471,73 +567,48 @@ apis: [
       },
       {
         date: 02.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 02.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 02.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 02.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 03.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.12.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 10,
             title: Sporadic erroneous rate limiting,
             api: API 1,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 03.12.2023 06:16:44 ,
+                datetime: 04.12.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 03.12.2023 08:30:07 ,
+                datetime: 04.12.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 03.12.2023 10:43:30 ,
+                datetime: 04.12.2023 10:43:30 ,
                 resolves: False
               },
             ],
           },
-        ]
-      },
-      {
-        date: 04.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
         ]
       },
       {
@@ -584,9 +655,34 @@ apis: [
       },
       {
         date: 11.12.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 11,
+            title: Service unreachable,
+            api: API 1,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 11.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 11.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 11.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -598,9 +694,28 @@ apis: [
       },
       {
         date: 13.12.2023,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 12,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 13.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 13.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -682,34 +797,9 @@ apis: [
       },
       {
         date: 25.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 25.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 25.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 25.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -742,9 +832,34 @@ apis: [
       },
       {
         date: 30.12.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 13,
+            title: Service unreachable,
+            api: API 1,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 30.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 30.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 30.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -763,34 +878,9 @@ apis: [
       },
       {
         date: 02.01.2024,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 02.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 02.01.2024 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 02.01.2024 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -809,41 +899,41 @@ apis: [
       },
       {
         date: 05.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 06.01.2024,
-        status: broken,
-        status-text: broken,
+        status: limited,
+        status-text: limited,
         incidents: [
           {
-            id: 2,
-            title: Service unreachable,
+            id: 14,
+            title: Sporadic erroneous rate limiting,
             api: API 1,
             updates: [
               {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 06.01.2024 06:16:44 ,
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 05.01.2024 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 06.01.2024 08:30:07 ,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 05.01.2024 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 06.01.2024 10:43:30 ,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 05.01.2024 10:43:30 ,
                 resolves: False
               },
             ],
           },
+        ]
+      },
+      {
+        date: 06.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -855,41 +945,41 @@ apis: [
       },
       {
         date: 08.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.01.2024,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 15,
             title: Sporadic erroneous rate limiting,
             api: API 1,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 08.01.2024 06:16:44 ,
+                datetime: 09.01.2024 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 08.01.2024 08:30:07 ,
+                datetime: 09.01.2024 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 08.01.2024 10:43:30 ,
+                datetime: 09.01.2024 10:43:30 ,
                 resolves: False
               },
             ],
           },
-        ]
-      },
-      {
-        date: 09.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
         ]
       },
       {
@@ -906,54 +996,104 @@ apis: [
         incidents: [
         ]
       },
+      {
+        date: 12.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 16,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 13.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 13.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 13.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 14.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
     ]
   },
   {
     name: API 2,
-    status: fine,
-    status-text: operational,
-    uptime: 87,
+    status: limited,
+    status-text: limited,
+    uptime: 83,
     days: [
       {
-        date: 13.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 14.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 15.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 17.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
         date: 18.10.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 17,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 18.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 18.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 18.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -972,28 +1112,9 @@ apis: [
       },
       {
         date: 21.10.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 21.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 21.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1030,7 +1151,7 @@ apis: [
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 18,
             title: Sporadic erroneous rate limiting,
             api: API 2,
             updates: [
@@ -1086,34 +1207,9 @@ apis: [
       },
       {
         date: 31.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 31.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 31.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 31.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1132,61 +1228,73 @@ apis: [
       },
       {
         date: 03.11.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 19,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 03.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 03.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 03.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
         date: 04.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 04.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 04.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 04.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 04.11.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 05.11.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 20,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 05.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 05.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 05.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1198,9 +1306,34 @@ apis: [
       },
       {
         date: 07.11.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 21,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 07.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 07.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 07.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1233,91 +1366,16 @@ apis: [
       },
       {
         date: 12.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 12.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 12.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 12.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 12.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 12.11.2023 15:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 12.11.2023 17:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 13.11.2023,
-        status: broken,
-        status-text: broken,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 2,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 13.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 13.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 13.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1385,34 +1443,9 @@ apis: [
       },
       {
         date: 23.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 23.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 23.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 23.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1480,9 +1513,34 @@ apis: [
       },
       {
         date: 03.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 22,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 03.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 03.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 03.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1498,7 +1556,7 @@ apis: [
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 23,
             title: Sporadic erroneous rate limiting,
             api: API 2,
             updates: [
@@ -1547,28 +1605,9 @@ apis: [
       },
       {
         date: 09.12.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 09.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 09.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1601,9 +1640,34 @@ apis: [
       },
       {
         date: 14.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 24,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 14.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 14.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 14.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1629,9 +1693,34 @@ apis: [
       },
       {
         date: 18.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 25,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 18.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 18.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 18.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1685,9 +1774,34 @@ apis: [
       },
       {
         date: 26.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 26,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 26.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 26.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 26.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1699,28 +1813,9 @@ apis: [
       },
       {
         date: 28.12.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 28.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 28.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1753,35 +1848,41 @@ apis: [
       },
       {
         date: 02.01.2024,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 02.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 02.01.2024 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 03.01.2024,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 27,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 03.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 03.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 03.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1793,9 +1894,34 @@ apis: [
       },
       {
         date: 05.01.2024,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 28,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 05.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 05.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 05.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1814,9 +1940,34 @@ apis: [
       },
       {
         date: 08.01.2024,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 29,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 08.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 08.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 08.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1840,49 +1991,99 @@ apis: [
         incidents: [
         ]
       },
+      {
+        date: 12.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 30,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 12.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 12.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 12.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 13.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 31,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 16.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 16.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 16.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
     ]
   },
   {
     name: API 3,
     status: fine,
     status-text: operational,
-    uptime: 82,
+    uptime: 83,
     days: [
-      {
-        date: 13.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 14.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 15.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 17.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
       {
         date: 18.10.2023,
         status: fine,
@@ -1927,66 +2128,16 @@ apis: [
       },
       {
         date: 24.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 24.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 24.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 24.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 25.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 25.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 25.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 25.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2005,24 +2156,30 @@ apis: [
       },
       {
         date: 28.10.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: limited,
+        status-text: limited,
         incidents: [
           {
-            id: 0,
-            title: Scheduled Maintenance,
+            id: 32,
+            title: Sporadic erroneous rate limiting,
             api: API 3,
             updates: [
               {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
                 datetime: 28.10.2023 06:16:44 ,
                 resolves: True
               },
               {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
                 datetime: 28.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 28.10.2023 10:43:30 ,
                 resolves: False
               },
             ],
@@ -2038,66 +2195,16 @@ apis: [
       },
       {
         date: 30.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 30.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 30.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 30.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 31.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 31.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 31.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 31.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2179,9 +2286,34 @@ apis: [
       },
       {
         date: 12.11.2023,
-        status: fine,
-        status-text: operational,
+        status: broken,
+        status-text: broken,
         incidents: [
+          {
+            id: 33,
+            title: Service unreachable,
+            api: API 3,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 12.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 12.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 12.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2200,41 +2332,35 @@ apis: [
       },
       {
         date: 15.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.11.2023,
-        status: limited,
-        status-text: limited,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
           {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
+            id: 34,
+            title: Scheduled Maintenance,
             api: API 3,
             updates: [
               {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 16.11.2023 06:16:44 ,
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 15.11.2023 06:16:44 ,
                 resolves: True
               },
               {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 16.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 16.11.2023 10:43:30 ,
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 15.11.2023 08:30:07 ,
                 resolves: False
               },
             ],
           },
+        ]
+      },
+      {
+        date: 16.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -2260,9 +2386,28 @@ apis: [
       },
       {
         date: 20.11.2023,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 35,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 20.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 20.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2274,85 +2419,16 @@ apis: [
       },
       {
         date: 22.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 22.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 22.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 22.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 22.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 22.11.2023 15:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 22.11.2023 17:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 23.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 23.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 23.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2371,9 +2447,34 @@ apis: [
       },
       {
         date: 26.11.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 36,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 26.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 26.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 26.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2385,41 +2486,66 @@ apis: [
       },
       {
         date: 28.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.11.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 37,
             title: Sporadic erroneous rate limiting,
             api: API 3,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 28.11.2023 06:16:44 ,
+                datetime: 29.11.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 28.11.2023 08:30:07 ,
+                datetime: 29.11.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 28.11.2023 10:43:30 ,
+                datetime: 29.11.2023 10:43:30 ,
                 resolves: False
               },
             ],
           },
-        ]
-      },
-      {
-        date: 29.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
+          {
+            id: 38,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 29.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 29.11.2023 15:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 29.11.2023 17:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2445,16 +2571,79 @@ apis: [
       },
       {
         date: 03.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 39,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 03.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 03.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 03.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
         date: 04.12.2023,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 40,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 41,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.12.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.12.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2487,34 +2676,9 @@ apis: [
       },
       {
         date: 09.12.2023,
-        status: broken,
-        status-text: broken,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 3,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 09.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 09.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 09.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2586,7 +2750,7 @@ apis: [
         status-text: maintenance,
         incidents: [
           {
-            id: 0,
+            id: 42,
             title: Scheduled Maintenance,
             api: API 3,
             updates: [
@@ -2600,6 +2764,25 @@ apis: [
                 title: Started,
                 text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
                 datetime: 19.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 43,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 19.12.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 19.12.2023 15:30:07 ,
                 resolves: False
               },
             ],
@@ -2650,37 +2833,30 @@ apis: [
       },
       {
         date: 26.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 27.12.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 44,
             title: Sporadic erroneous rate limiting,
             api: API 3,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 27.12.2023 06:16:44 ,
+                datetime: 26.12.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 27.12.2023 08:30:07 ,
+                datetime: 26.12.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 27.12.2023 10:43:30 ,
+                datetime: 26.12.2023 10:43:30 ,
                 resolves: False
               },
             ],
@@ -2688,10 +2864,36 @@ apis: [
         ]
       },
       {
-        date: 28.12.2023,
+        date: 27.12.2023,
         status: fine,
         status-text: operational,
         incidents: [
+        ]
+      },
+      {
+        date: 28.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 45,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 28.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 28.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2703,28 +2905,9 @@ apis: [
       },
       {
         date: 30.12.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 30.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 30.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2743,34 +2926,9 @@ apis: [
       },
       {
         date: 02.01.2024,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 02.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 02.01.2024 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 02.01.2024 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2782,47 +2940,9 @@ apis: [
       },
       {
         date: 04.01.2024,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 04.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 04.01.2024 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 04.01.2024 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 04.01.2024 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2834,16 +2954,66 @@ apis: [
       },
       {
         date: 06.01.2024,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 46,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 06.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 06.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 06.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
         date: 07.01.2024,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 47,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 07.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 07.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 07.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2855,41 +3025,41 @@ apis: [
       },
       {
         date: 09.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 10.01.2024,
         status: limited,
         status-text: limited,
         incidents: [
           {
-            id: 1,
+            id: 48,
             title: Sporadic erroneous rate limiting,
             api: API 3,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 10.01.2024 06:16:44 ,
+                datetime: 09.01.2024 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 10.01.2024 08:30:07 ,
+                datetime: 09.01.2024 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 10.01.2024 10:43:30 ,
+                datetime: 09.01.2024 10:43:30 ,
                 resolves: False
               },
             ],
           },
+        ]
+      },
+      {
+        date: 10.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -2899,7 +3069,1770 @@ apis: [
         incidents: [
         ]
       },
+      {
+        date: 12.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 49,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 14.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 14.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 14.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 15.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
     ]
+  },
+]
+incidents-by-day: [
+  {
+  date: 16.01.2024,
+    incidents: [
+      {
+        id: 31,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 16.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 16.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 16.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 15.01.2024,
+    incidents: [
+    ],
+  },
+  {
+  date: 14.01.2024,
+    incidents: [
+      {
+        id: 49,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 14.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 14.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 14.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 13.01.2024,
+    incidents: [
+      {
+        id: 16,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 13.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 13.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 13.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 12.01.2024,
+    incidents: [
+      {
+        id: 30,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 12.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 12.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 12.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 11.01.2024,
+    incidents: [
+    ],
+  },
+  {
+  date: 10.01.2024,
+    incidents: [
+    ],
+  },
+  {
+  date: 09.01.2024,
+    incidents: [
+      {
+        id: 15,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 09.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 09.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 09.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 48,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 09.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 09.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 09.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 08.01.2024,
+    incidents: [
+      {
+        id: 29,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 08.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 08.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 08.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 07.01.2024,
+    incidents: [
+      {
+        id: 47,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 07.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 07.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 07.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 06.01.2024,
+    incidents: [
+      {
+        id: 46,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 06.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 06.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 06.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 05.01.2024,
+    incidents: [
+      {
+        id: 14,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 05.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 05.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 05.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 28,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 05.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 05.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 05.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 04.01.2024,
+    incidents: [
+    ],
+  },
+  {
+  date: 03.01.2024,
+    incidents: [
+      {
+        id: 27,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 03.01.2024 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 03.01.2024 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 03.01.2024 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 02.01.2024,
+    incidents: [
+    ],
+  },
+  {
+  date: 01.01.2024,
+    incidents: [
+    ],
+  },
+  {
+  date: 31.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 30.12.2023,
+    incidents: [
+      {
+        id: 13,
+        severity: broken,
+        title: Service unreachable,
+        api: API 1,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 30.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 30.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 30.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 29.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 28.12.2023,
+    incidents: [
+      {
+        id: 45,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 28.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 28.12.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 27.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 26.12.2023,
+    incidents: [
+      {
+        id: 26,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 26.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 26.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 26.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 44,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 26.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 26.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 26.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 25.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 24.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 23.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 22.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 21.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 20.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 19.12.2023,
+    incidents: [
+      {
+        id: 42,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 19.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 19.12.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 43,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 19.12.2023 13:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 19.12.2023 15:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 18.12.2023,
+    incidents: [
+      {
+        id: 25,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 18.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 18.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 18.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 17.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 16.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 15.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 14.12.2023,
+    incidents: [
+      {
+        id: 24,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 14.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 14.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 14.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 13.12.2023,
+    incidents: [
+      {
+        id: 12,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 1,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 13.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 13.12.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 12.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 11.12.2023,
+    incidents: [
+      {
+        id: 11,
+        severity: broken,
+        title: Service unreachable,
+        api: API 1,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 11.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 11.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 11.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 10.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 09.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 08.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 07.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 06.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 05.12.2023,
+    incidents: [
+      {
+        id: 23,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 05.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 05.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 05.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 04.12.2023,
+    incidents: [
+      {
+        id: 10,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 04.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 04.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 04.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 40,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 04.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 04.12.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 41,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 04.12.2023 13:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 04.12.2023 15:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 03.12.2023,
+    incidents: [
+      {
+        id: 22,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 03.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 03.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 03.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 39,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 03.12.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 03.12.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 03.12.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 02.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 01.12.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 30.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 29.11.2023,
+    incidents: [
+      {
+        id: 37,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 29.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 29.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 29.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 38,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 29.11.2023 13:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 29.11.2023 15:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 29.11.2023 17:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 28.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 27.11.2023,
+    incidents: [
+      {
+        id: 9,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 27.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 27.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 27.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 26.11.2023,
+    incidents: [
+      {
+        id: 36,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 26.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 26.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 26.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 25.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 24.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 23.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 22.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 21.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 20.11.2023,
+    incidents: [
+      {
+        id: 7,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 20.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 20.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 20.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 8,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 20.11.2023 13:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 20.11.2023 15:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 20.11.2023 17:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 35,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 20.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 20.11.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 19.11.2023,
+    incidents: [
+      {
+        id: 6,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 19.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 19.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 19.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 18.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 17.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 16.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 15.11.2023,
+    incidents: [
+      {
+        id: 5,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 15.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 15.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 15.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 34,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 3,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 15.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 15.11.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 14.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 13.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 12.11.2023,
+    incidents: [
+      {
+        id: 33,
+        severity: broken,
+        title: Service unreachable,
+        api: API 3,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 12.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 12.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 12.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 11.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 10.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 09.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 08.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 07.11.2023,
+    incidents: [
+      {
+        id: 4,
+        severity: maintenance,
+        title: Scheduled Maintenance,
+        api: API 1,
+        updates: [
+          {
+            title: Done,
+            text: Finished maintenance session. Service is back up.,
+            datetime: 07.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Started,
+            text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+            datetime: 07.11.2023 08:30:07 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 21,
+        severity: broken,
+        title: Service unreachable,
+        api: API 2,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 07.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 07.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 07.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 06.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 05.11.2023,
+    incidents: [
+      {
+        id: 20,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 05.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 05.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 05.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 04.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 03.11.2023,
+    incidents: [
+      {
+        id: 19,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 03.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 03.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 03.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 02.11.2023,
+    incidents: [
+      {
+        id: 3,
+        severity: broken,
+        title: Service unreachable,
+        api: API 1,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 02.11.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 02.11.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 02.11.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 01.11.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 31.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 30.10.2023,
+    incidents: [
+      {
+        id: 2,
+        severity: broken,
+        title: Service unreachable,
+        api: API 1,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 30.10.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 30.10.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 30.10.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 29.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 28.10.2023,
+    incidents: [
+      {
+        id: 32,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 3,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 28.10.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 28.10.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 28.10.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 27.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 26.10.2023,
+    incidents: [
+      {
+        id: 18,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 2,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 26.10.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 26.10.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 26.10.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 25.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 24.10.2023,
+    incidents: [
+      {
+        id: 1,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 24.10.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 24.10.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 24.10.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
+  },
+  {
+  date: 23.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 22.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 21.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 20.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 19.10.2023,
+    incidents: [
+    ],
+  },
+  {
+  date: 18.10.2023,
+    incidents: [
+      {
+        id: 0,
+        severity: limited,
+        title: Sporadic erroneous rate limiting,
+        api: API 1,
+        updates: [
+          {
+            title: Resolved,
+            text: We have corrected the faulty rate limiting configuration.,
+            datetime: 18.10.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: Our internal monitoring has confirmed these reports.,
+            datetime: 18.10.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+            datetime: 18.10.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+      {
+        id: 17,
+        severity: broken,
+        title: Service unreachable,
+        api: API 2,
+        updates: [
+          {
+            title: Identified,
+            text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+            datetime: 18.10.2023 06:16:44 ,
+            resolves: True
+          },
+          {
+            title: Investigating,
+            text: We have determined that the service itself is unreachable. The server running it seems fine.,
+            datetime: 18.10.2023 08:30:07 ,
+            resolves: False
+          },
+          {
+            title: Notified,
+            text: We have received an automated warning about the service.,
+            datetime: 18.10.2023 10:43:30 ,
+            resolves: False
+          },
+        ],
+      },
+    ],
   },
 ]
 ---

--- a/html-prototype/data.yaml
+++ b/html-prototype/data.yaml
@@ -4,15 +4,8 @@ apis: [
     name: API 1,
     status: fine,
     status-text: operational,
-    uptime: 1.28,
+    uptime: 89,
     days: [
-      {
-        date: 12.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
       {
         date: 13.10.2023,
         status: fine,
@@ -22,9 +15,34 @@ apis: [
       },
       {
         date: 14.10.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 14.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 14.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 14.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -64,28 +82,9 @@ apis: [
       },
       {
         date: 20.10.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 20.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 20.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -125,28 +124,9 @@ apis: [
       },
       {
         date: 26.10.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 26.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 26.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -165,28 +145,9 @@ apis: [
       },
       {
         date: 29.10.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 29.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 29.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -198,34 +159,9 @@ apis: [
       },
       {
         date: 31.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 31.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 31.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 31.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -244,34 +180,9 @@ apis: [
       },
       {
         date: 03.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 03.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 03.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 03.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -304,47 +215,9 @@ apis: [
       },
       {
         date: 08.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 08.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 08.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 08.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 08.11.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -370,66 +243,16 @@ apis: [
       },
       {
         date: 12.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 12.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 12.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 12.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 13.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 13.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 13.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 13.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -494,9 +317,47 @@ apis: [
       },
       {
         date: 19.11.2023,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 19.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 19.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 1,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 19.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 19.11.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -550,41 +411,41 @@ apis: [
       },
       {
         date: 27.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 28.11.2023,
-        status: limited,
-        status-text: limited,
+        status: broken,
+        status-text: broken,
         incidents: [
           {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
+            id: 2,
+            title: Service unreachable,
             api: API 1,
             updates: [
               {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 28.11.2023 06:16:44 ,
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 27.11.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 28.11.2023 08:30:07 ,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 27.11.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 28.11.2023 10:43:30 ,
+                text: We have received an automated warning about the service.,
+                datetime: 27.11.2023 10:43:30 ,
                 resolves: False
               },
             ],
           },
+        ]
+      },
+      {
+        date: 28.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -603,34 +464,9 @@ apis: [
       },
       {
         date: 01.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 01.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 01.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 01.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -667,9 +503,34 @@ apis: [
       },
       {
         date: 03.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 03.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 03.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 03.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -695,34 +556,9 @@ apis: [
       },
       {
         date: 07.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 07.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 07.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 07.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -776,28 +612,9 @@ apis: [
       },
       {
         date: 15.12.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 1,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 15.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 15.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -823,34 +640,9 @@ apis: [
       },
       {
         date: 19.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 19.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 19.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 19.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -890,9 +682,34 @@ apis: [
       },
       {
         date: 25.12.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 1,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 25.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 25.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 25.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -939,34 +756,9 @@ apis: [
       },
       {
         date: 01.01.2024,
-        status: broken,
-        status-text: broken,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 1,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 01.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 01.01.2024 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 01.01.2024 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1010,34 +802,9 @@ apis: [
       },
       {
         date: 04.01.2024,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 1,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 04.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 04.01.2024 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 04.01.2024 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1049,31 +816,30 @@ apis: [
       },
       {
         date: 06.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 07.01.2024,
-        status: maintenance,
-        status-text: maintenance,
+        status: broken,
+        status-text: broken,
         incidents: [
           {
-            id: 0,
-            title: Scheduled Maintenance,
+            id: 2,
+            title: Service unreachable,
             api: API 1,
             updates: [
               {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 07.01.2024 06:16:44 ,
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 06.01.2024 06:16:44 ,
                 resolves: True
               },
               {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 07.01.2024 08:30:07 ,
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 06.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 06.01.2024 10:43:30 ,
                 resolves: False
               },
             ],
@@ -1081,14 +847,14 @@ apis: [
         ]
       },
       {
-        date: 08.01.2024,
+        date: 07.01.2024,
         status: fine,
         status-text: operational,
         incidents: [
         ]
       },
       {
-        date: 09.01.2024,
+        date: 08.01.2024,
         status: limited,
         status-text: limited,
         incidents: [
@@ -1100,23 +866,30 @@ apis: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 09.01.2024 06:16:44 ,
+                datetime: 08.01.2024 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 09.01.2024 08:30:07 ,
+                datetime: 08.01.2024 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 09.01.2024 10:43:30 ,
+                datetime: 08.01.2024 10:43:30 ,
                 resolves: False
               },
             ],
           },
+        ]
+      },
+      {
+        date: 09.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -1126,21 +899,21 @@ apis: [
         incidents: [
         ]
       },
-    ]
-  },
-  {
-    name: API 2,
-    status: broken,
-    status-text: broken,
-    uptime: 1.20,
-    days: [
       {
-        date: 12.10.2023,
+        date: 11.01.2024,
         status: fine,
         status-text: operational,
         incidents: [
         ]
       },
+    ]
+  },
+  {
+    name: API 2,
+    status: fine,
+    status-text: operational,
+    uptime: 87,
+    days: [
       {
         date: 13.10.2023,
         status: fine,
@@ -1157,34 +930,9 @@ apis: [
       },
       {
         date: 15.10.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 15.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 15.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 15.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1196,28 +944,9 @@ apis: [
       },
       {
         date: 17.10.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 17.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 17.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1243,13 +972,6 @@ apis: [
       },
       {
         date: 21.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 22.10.2023,
         status: maintenance,
         status-text: maintenance,
         incidents: [
@@ -1261,36 +983,24 @@ apis: [
               {
                 title: Done,
                 text: Finished maintenance session. Service is back up.,
-                datetime: 22.10.2023 06:16:44 ,
+                datetime: 21.10.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Started,
                 text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 22.10.2023 08:30:07 ,
+                datetime: 21.10.2023 08:30:07 ,
                 resolves: False
               },
             ],
           },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 22.10.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 22.10.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
+        ]
+      },
+      {
+        date: 22.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -1376,9 +1086,1018 @@ apis: [
       },
       {
         date: 31.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 31.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 31.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 31.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 01.11.2023,
         status: fine,
         status-text: operational,
         incidents: [
+        ]
+      },
+      {
+        date: 02.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.11.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.11.2023 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 05.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 12.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 12.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 12.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 12.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 12.11.2023 15:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 12.11.2023 17:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 13.11.2023,
+        status: broken,
+        status-text: broken,
+        incidents: [
+          {
+            id: 2,
+            title: Service unreachable,
+            api: API 2,
+            updates: [
+              {
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                datetime: 13.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                datetime: 13.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We have received an automated warning about the service.,
+                datetime: 13.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 14.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.11.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 23.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 23.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 23.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 24.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 29.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 03.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.12.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 2,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 05.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 05.12.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 05.12.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 06.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 09.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 09.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 10.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 12.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 13.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 25.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 26.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.12.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 28.12.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 28.12.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 29.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 31.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 01.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.01.2024,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 2,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 02.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 02.01.2024 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 03.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 04.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 05.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 06.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 07.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 08.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 09.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 10.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 11.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+    ]
+  },
+  {
+    name: API 3,
+    status: fine,
+    status-text: operational,
+    uptime: 82,
+    days: [
+      {
+        date: 13.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 14.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 15.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 16.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 17.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 20.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 21.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 23.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 24.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 24.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 24.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 24.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 25.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 25.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 25.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 25.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 26.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 27.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 28.10.2023,
+        status: maintenance,
+        status-text: maintenance,
+        incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 28.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 28.10.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 29.10.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 30.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 30.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 30.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 30.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+        ]
+      },
+      {
+        date: 31.10.2023,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 31.10.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 31.10.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 31.10.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1425,98 +2144,23 @@ apis: [
       },
       {
         date: 07.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 07.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 07.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 07.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 08.11.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 08.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 08.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 08.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 09.11.2023,
-        status: broken,
-        status-text: broken,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 2,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 09.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 09.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 09.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1528,28 +2172,9 @@ apis: [
       },
       {
         date: 11.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 11.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 11.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1582,37 +2207,30 @@ apis: [
       },
       {
         date: 16.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 17.11.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
             id: 1,
             title: Sporadic erroneous rate limiting,
-            api: API 2,
+            api: API 3,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 17.11.2023 06:16:44 ,
+                datetime: 16.11.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 17.11.2023 08:30:07 ,
+                datetime: 16.11.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 17.11.2023 10:43:30 ,
+                datetime: 16.11.2023 10:43:30 ,
                 resolves: False
               },
             ],
@@ -1620,29 +2238,17 @@ apis: [
         ]
       },
       {
-        date: 18.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        date: 17.11.2023,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 18.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 18.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
+        ]
+      },
+      {
+        date: 18.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
         ]
       },
       {
@@ -1661,30 +2267,62 @@ apis: [
       },
       {
         date: 21.11.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 22.11.2023,
         status: limited,
         status-text: limited,
         incidents: [
           {
             id: 1,
             title: Sporadic erroneous rate limiting,
-            api: API 2,
+            api: API 3,
             updates: [
               {
                 title: Resolved,
                 text: We have corrected the faulty rate limiting configuration.,
-                datetime: 21.11.2023 06:16:44 ,
+                datetime: 22.11.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
                 text: Our internal monitoring has confirmed these reports.,
-                datetime: 21.11.2023 08:30:07 ,
+                datetime: 22.11.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
                 text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 21.11.2023 10:43:30 ,
+                datetime: 22.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 22.11.2023 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 22.11.2023 15:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 22.11.2023 17:43:30 ,
                 resolves: False
               },
             ],
@@ -1692,17 +2330,29 @@ apis: [
         ]
       },
       {
-        date: 22.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
         date: 23.11.2023,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 23.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 23.11.2023 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1721,80 +2371,48 @@ apis: [
       },
       {
         date: 26.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 26.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 26.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 26.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 26.11.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 27.11.2023,
-        status: maintenance,
-        status-text: maintenance,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 27.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 27.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 28.11.2023,
-        status: fine,
-        status-text: operational,
+        status: limited,
+        status-text: limited,
         incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 28.11.2023 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 28.11.2023 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 28.11.2023 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -1813,34 +2431,9 @@ apis: [
       },
       {
         date: 01.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 01.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 01.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 01.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1852,34 +2445,9 @@ apis: [
       },
       {
         date: 03.12.2023,
-        status: broken,
-        status-text: broken,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 2,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 03.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 03.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 03.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -1912,86 +2480,36 @@ apis: [
       },
       {
         date: 08.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 08.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 08.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 08.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 08.12.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 08.12.2023 15:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 08.12.2023 17:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 09.12.2023,
-        status: limited,
-        status-text: limited,
+        status: broken,
+        status-text: broken,
         incidents: [
           {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
+            id: 2,
+            title: Service unreachable,
+            api: API 3,
             updates: [
               {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
+                title: Identified,
+                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
                 datetime: 09.12.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
+                text: We have determined that the service itself is unreachable. The server running it seems fine.,
                 datetime: 09.12.2023 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                text: We have received an automated warning about the service.,
                 datetime: 09.12.2023 10:43:30 ,
                 resolves: False
               },
@@ -2050,107 +2568,38 @@ apis: [
       },
       {
         date: 17.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 18.12.2023,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 19.12.2023,
         status: maintenance,
         status-text: maintenance,
         incidents: [
           {
             id: 0,
             title: Scheduled Maintenance,
-            api: API 2,
+            api: API 3,
             updates: [
               {
                 title: Done,
                 text: Finished maintenance session. Service is back up.,
-                datetime: 17.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 17.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 2,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 17.12.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 17.12.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 18.12.2023,
-        status: broken,
-        status-text: broken,
-        incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 2,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 18.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 18.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 18.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 19.12.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
                 datetime: 19.12.2023 06:16:44 ,
                 resolves: True
               },
               {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
                 datetime: 19.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 19.12.2023 10:43:30 ,
                 resolves: False
               },
             ],
@@ -2173,66 +2622,16 @@ apis: [
       },
       {
         date: 22.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 22.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 22.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 22.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
         date: 23.12.2023,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 23.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 23.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 23.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2264,7 +2663,7 @@ apis: [
           {
             id: 1,
             title: Sporadic erroneous rate limiting,
-            api: API 2,
+            api: API 3,
             updates: [
               {
                 title: Resolved,
@@ -2304,63 +2703,24 @@ apis: [
       },
       {
         date: 30.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 31.12.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 31.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 31.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 31.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 01.01.2024,
         status: maintenance,
         status-text: maintenance,
         incidents: [
           {
             id: 0,
             title: Scheduled Maintenance,
-            api: API 2,
+            api: API 3,
             updates: [
               {
                 title: Done,
                 text: Finished maintenance session. Service is back up.,
-                datetime: 01.01.2024 06:16:44 ,
+                datetime: 30.12.2023 06:16:44 ,
                 resolves: True
               },
               {
                 title: Started,
                 text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 01.01.2024 08:30:07 ,
+                datetime: 30.12.2023 08:30:07 ,
                 resolves: False
               },
             ],
@@ -2368,10 +2728,49 @@ apis: [
         ]
       },
       {
-        date: 02.01.2024,
+        date: 31.12.2023,
         status: fine,
         status-text: operational,
         incidents: [
+        ]
+      },
+      {
+        date: 01.01.2024,
+        status: fine,
+        status-text: operational,
+        incidents: [
+        ]
+      },
+      {
+        date: 02.01.2024,
+        status: limited,
+        status-text: limited,
+        incidents: [
+          {
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
+            updates: [
+              {
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
+                datetime: 02.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Investigating,
+                text: Our internal monitoring has confirmed these reports.,
+                datetime: 02.01.2024 08:30:07 ,
+                resolves: False
+              },
+              {
+                title: Notified,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
+                datetime: 02.01.2024 10:43:30 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2383,9 +2782,47 @@ apis: [
       },
       {
         date: 04.01.2024,
-        status: fine,
-        status-text: operational,
+        status: maintenance,
+        status-text: maintenance,
         incidents: [
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.01.2024 06:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.01.2024 08:30:07 ,
+                resolves: False
+              },
+            ],
+          },
+          {
+            id: 0,
+            title: Scheduled Maintenance,
+            api: API 3,
+            updates: [
+              {
+                title: Done,
+                text: Finished maintenance session. Service is back up.,
+                datetime: 04.01.2024 13:16:44 ,
+                resolves: True
+              },
+              {
+                title: Started,
+                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
+                datetime: 04.01.2024 15:30:07 ,
+                resolves: False
+              },
+            ],
+          },
         ]
       },
       {
@@ -2397,34 +2834,9 @@ apis: [
       },
       {
         date: 06.01.2024,
-        status: limited,
-        status-text: limited,
+        status: fine,
+        status-text: operational,
         incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 2,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 06.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 06.01.2024 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 06.01.2024 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
         ]
       },
       {
@@ -2450,29 +2862,29 @@ apis: [
       },
       {
         date: 10.01.2024,
-        status: broken,
-        status-text: broken,
+        status: limited,
+        status-text: limited,
         incidents: [
           {
-            id: 2,
-            title: Service unreachable,
-            api: API 2,
+            id: 1,
+            title: Sporadic erroneous rate limiting,
+            api: API 3,
             updates: [
               {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
+                title: Resolved,
+                text: We have corrected the faulty rate limiting configuration.,
                 datetime: 10.01.2024 06:16:44 ,
                 resolves: True
               },
               {
                 title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
+                text: Our internal monitoring has confirmed these reports.,
                 datetime: 10.01.2024 08:30:07 ,
                 resolves: False
               },
               {
                 title: Notified,
-                text: We have received an automated warning about the service.,
+                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
                 datetime: 10.01.2024 10:43:30 ,
                 resolves: False
               },
@@ -2480,1174 +2892,8 @@ apis: [
           },
         ]
       },
-    ]
-  },
-  {
-    name: API 3,
-    status: fine,
-    status-text: operational,
-    uptime: 1.28,
-    days: [
       {
-        date: 12.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 13.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 14.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 15.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 17.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 18.10.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 18.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 18.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 18.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 19.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 20.10.2023,
-        status: broken,
-        status-text: broken,
-        incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 3,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 20.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 20.10.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 20.10.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 21.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 22.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 23.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 24.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 25.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 26.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 27.10.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 27.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 27.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 28.10.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 28.10.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 28.10.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 29.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 30.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 31.10.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 01.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 02.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 03.11.2023,
-        status: broken,
-        status-text: broken,
-        incidents: [
-          {
-            id: 2,
-            title: Service unreachable,
-            api: API 3,
-            updates: [
-              {
-                title: Identified,
-                text: We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.,
-                datetime: 03.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: We have determined that the service itself is unreachable. The server running it seems fine.,
-                datetime: 03.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We have received an automated warning about the service.,
-                datetime: 03.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 04.11.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 04.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 04.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 04.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 05.11.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 05.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 05.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 05.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 06.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 07.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 08.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 09.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 10.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 11.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 12.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 13.11.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 13.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 13.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 14.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 15.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 17.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 18.11.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 18.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 18.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 18.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 19.11.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 19.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 19.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 19.11.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 19.11.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 20.11.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 20.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 20.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 20.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 21.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 22.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 23.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 24.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 25.11.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 25.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 25.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 25.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 26.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 27.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 28.11.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 28.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 28.11.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 29.11.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 30.11.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 30.11.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 30.11.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 30.11.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 01.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 02.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 03.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 04.12.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 04.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 04.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 04.12.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 04.12.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 05.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 06.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 07.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 08.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 09.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 10.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 11.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 12.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 13.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 14.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 15.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 16.12.2023,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 16.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 16.12.2023 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 16.12.2023 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 17.12.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 17.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 17.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 17.12.2023 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 17.12.2023 15:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 18.12.2023,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 18.12.2023 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 18.12.2023 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 19.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 20.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 21.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 22.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 23.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 24.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 25.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 26.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 27.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 28.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 29.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 30.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 31.12.2023,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 01.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 02.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 03.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 04.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 05.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 06.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 07.01.2024,
-        status: limited,
-        status-text: limited,
-        incidents: [
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 07.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 07.01.2024 08:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 07.01.2024 10:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-          {
-            id: 1,
-            title: Sporadic erroneous rate limiting,
-            api: API 3,
-            updates: [
-              {
-                title: Resolved,
-                text: We have corrected the faulty rate limiting configuration.,
-                datetime: 07.01.2024 13:16:44 ,
-                resolves: True
-              },
-              {
-                title: Investigating,
-                text: Our internal monitoring has confirmed these reports.,
-                datetime: 07.01.2024 15:30:07 ,
-                resolves: False
-              },
-              {
-                title: Notified,
-                text: We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.,
-                datetime: 07.01.2024 17:43:30 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 08.01.2024,
-        status: maintenance,
-        status-text: maintenance,
-        incidents: [
-          {
-            id: 0,
-            title: Scheduled Maintenance,
-            api: API 3,
-            updates: [
-              {
-                title: Done,
-                text: Finished maintenance session. Service is back up.,
-                datetime: 08.01.2024 06:16:44 ,
-                resolves: True
-              },
-              {
-                title: Started,
-                text: Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.,
-                datetime: 08.01.2024 08:30:07 ,
-                resolves: False
-              },
-            ],
-          },
-        ]
-      },
-      {
-        date: 09.01.2024,
-        status: fine,
-        status-text: operational,
-        incidents: [
-        ]
-      },
-      {
-        date: 10.01.2024,
+        date: 11.01.2024,
         status: fine,
         status-text: operational,
         incidents: [

--- a/html-prototype/generate-data.py
+++ b/html-prototype/generate-data.py
@@ -7,8 +7,7 @@ import random
 PRELUDE = """---
 apis: ["""
 
-END = """]
----
+END = """---
 """
 
 APIS = ["API 1", "API 2", "API 3"]
@@ -37,8 +36,9 @@ class DayData:
 
 class Incident:
 
-    def __init__(self, id, title, updates, resolved=False):
+    def __init__(self, id, severity, title, updates, resolved=False):
         self.id = id
+        self.severity = severity
         self.title = title
         self.updates = updates
         self.resolved = resolved
@@ -68,7 +68,8 @@ class IncidentUpdate:
 
 INCIDENTS = {
     "maintenance": Incident(
-        0,
+        -1,
+        "maintenance",
         "Scheduled Maintenance",
         [
             IncidentUpdate(
@@ -83,7 +84,8 @@ INCIDENTS = {
         ]
     ),
     "limited": Incident(
-        1,
+        -1,
+        "limited",
         "Sporadic erroneous rate limiting",
         [
             IncidentUpdate(
@@ -102,7 +104,8 @@ INCIDENTS = {
         ]
     ),
     "broken": Incident(
-        2,
+        -1,
+        "broken",
         "Service unreachable",
         [
             IncidentUpdate(
@@ -129,11 +132,17 @@ RESOLVING_UPDATES_MAINTENANCE = [
     )
 ]
 
+id_counter = 0
+incidents_by_day = {}
+
 def w(file, text):
     file.write(text + "\n")
 
 def get_incident(api, day, additional_hours=0):
     incident = copy.deepcopy(INCIDENTS[day.status])
+    global id_counter
+    incident.id = id_counter
+    id_counter += 1
     incident.api = api
     incident.add_date(day.date, additional_hours)
     return incident
@@ -153,6 +162,8 @@ if __name__ == "__main__":
             day_data = []
             for dt in rrule(DAILY, dtstart=start, until=end):
                 day = DayData(dt)
+                if day.date not in incidents_by_day:
+                    incidents_by_day[day.date] = []
                 day.status = random.choices(DAY_STATUS, random.choice(DAY_STATUS_WEIGHTS))[0]
                 day.status_text = STATUS_TEXTS[day.status]
                 if day.status == "limited":
@@ -165,6 +176,7 @@ if __name__ == "__main__":
                     day.incidents.append(get_incident(api, day))
                     if random.randrange(10) > 8:
                         day.incidents.append(get_incident(api, day, 7))
+                incidents_by_day[day.date] += day.incidents
                 day_data.append(day)
             days_total = len(day_data)
             days_fine = days_total - days_limited - days_broken - days_maintenance
@@ -200,5 +212,29 @@ if __name__ == "__main__":
                 w(f,  "      },")
             w(f, "    ]")
             w(f, "  },")
-        
+        w(f, "]")
+        w(f, "incidents-by-day: [")
+        for day, incidents in reversed(incidents_by_day.items()):
+            w(f, "  {")
+            w(f, f"  date: {day:%d.%m.%Y},")
+            w(f, "    incidents: [")
+            for incident in incidents:
+                w(f, "      {")
+                w(f, f"        id: {incident.id},")
+                w(f, f"        severity: {incident.severity},")
+                w(f, f"        title: {incident.title},")
+                w(f, f"        api: {incident.api},")
+                w(f, f"        updates: [")
+                for update in incident.updates:
+                    w(f,  "          {")
+                    w(f, f"            title: {update.title},")
+                    w(f, f"            text: {update.text},")
+                    w(f, f"            datetime: {update.datetime:%d.%m.%Y %H:%M:%S %Z},")
+                    w(f, f"            resolves: {update.resolves}")
+                    w(f,  "          },")    
+                w(f, f"        ],")
+                w(f, "      },")
+            w(f, "    ],")
+            w(f, "  },")
+        w(f, "]")
         w(f, END)

--- a/html-prototype/generate-data.py
+++ b/html-prototype/generate-data.py
@@ -14,7 +14,11 @@ END = """]
 APIS = ["API 1", "API 2", "API 3"]
 
 DAY_STATUS = ["fine", "limited", "broken", "maintenance"]
-DAY_STATUS_WEIGHTS = [24, 4, 1, 2]
+DAY_STATUS_WEIGHTS = [
+    [30, 4, 1, 2],
+    [45, 2, 1, 1],
+    [36, 6, 1, 2]
+]
 
 STATUS_TEXTS = {
     "fine": "operational",
@@ -149,7 +153,7 @@ if __name__ == "__main__":
             day_data = []
             for dt in rrule(DAILY, dtstart=start, until=end):
                 day = DayData(dt)
-                day.status = random.choices(DAY_STATUS, DAY_STATUS_WEIGHTS)[0]
+                day.status = random.choices(DAY_STATUS, random.choice(DAY_STATUS_WEIGHTS))[0]
                 day.status_text = STATUS_TEXTS[day.status]
                 if day.status == "limited":
                     days_limited = days_limited + 1
@@ -164,12 +168,12 @@ if __name__ == "__main__":
                 day_data.append(day)
             days_total = len(day_data)
             days_fine = days_total - days_limited - days_broken - days_maintenance
-            uptime = (days_total - (days_limited + days_broken + days_maintenance)) / days_total
+            uptime = days_fine / days_total
             status = day_data[-1].status
             status_text = STATUS_TEXTS[status]
             w(f, f"    status: {status},")
             w(f, f"    status-text: {status_text},")
-            w(f, f"    uptime: {uptime + 0.5:.2f},")
+            w(f, f"    uptime: {int(uptime * 100):2d},")
             w(f, f"    days: [")
             for day in day_data:
                 w(f, "      {")

--- a/html-prototype/index.html
+++ b/html-prototype/index.html
@@ -11,8 +11,17 @@
 
 <body onload="init()">
     <header>
-        <img alt="" title="SCS Project" src="assets/scs-logo.svg">
-        <button type="button" class="subscribe-btn">Subscribe to Updates</button>
+        <div>
+            <img alt="" title="SCS Project" src="assets/scs-logo.svg">
+            <button type="button" class="subscribe-btn">Subscribe to Updates</button>
+        </div>
+        <div>
+            <a href="#accessibility-options">Skip to accessibility options</a>
+            <span>
+                <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
+                <input id="tableHideFineDays" type="checkbox" onclick="switchTableHideOperationalDays()" disabled></input><label id="tableHideFineDaysLabel" class="disabled" for="tableHideFineDays">Hide operational days (table display only)</label>
+            </span>
+        </div>
     </header>
     <main>
         <div class="status-bar status-fine">
@@ -34,68 +43,23 @@
                         <div class="status-bar status-fine">operational</div>
                     </div>
                     <div class="api-daily-status">
-                            <div class="day-status-box status-fine">
+                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>13.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-limited">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>14.10.2023</h5></span>
+                                            <span><h5>18.10.2023</h5></span>
                                             <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>15.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>16.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>17.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>18.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -105,7 +69,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -115,7 +82,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -125,7 +95,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -135,7 +108,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -145,17 +121,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-23.10.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>24.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -165,7 +148,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-25.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -175,7 +161,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -185,7 +174,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-27.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -195,7 +187,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -205,17 +200,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-29.10.2023"></a>
+                            </div>                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -225,7 +227,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-31.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -235,17 +240,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-01.11.2023"></a>
+                            </div>                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>02.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-02.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -255,7 +267,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-03.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -265,7 +280,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-04.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -275,7 +293,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-05.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -285,17 +306,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-06.11.2023"></a>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>07.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -305,7 +333,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-08.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -315,7 +346,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -325,7 +359,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -335,7 +372,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -345,7 +385,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-12.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -355,7 +398,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-13.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -365,17 +411,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-14.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>15.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-15.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -385,7 +438,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-16.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -395,40 +451,52 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-17.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.11.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-18.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.11.2023</h5></span>
                                             <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>19.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-19.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>20.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -438,7 +506,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -448,7 +519,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -458,7 +532,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -468,7 +545,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -478,7 +558,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-25.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -488,18 +571,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                                <a href="#incidents-26.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>27.11.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-27.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -509,7 +598,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -519,7 +611,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-29.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -529,7 +624,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -539,39 +637,50 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-01.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>02.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-limited">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>03.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>04.12.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-02.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-03.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>04.12.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-04.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -581,7 +690,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-05.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -591,7 +703,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-06.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -601,7 +716,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -611,7 +729,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-08.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -621,7 +742,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -631,17 +755,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-10.12.2023"></a>
+                            </div>                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>11.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -651,17 +782,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-12.12.2023"></a>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>13.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-13.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -671,7 +809,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-14.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -681,7 +822,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-15.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -691,7 +835,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-16.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -701,7 +848,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-17.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -711,7 +861,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -721,7 +874,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -731,7 +887,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -741,7 +900,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -751,7 +913,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -761,7 +926,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -771,18 +939,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-24.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>25.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-25.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -792,7 +965,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -802,7 +978,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-27.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -812,7 +991,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -822,17 +1004,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-29.12.2023"></a>
+                            </div>                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -842,7 +1031,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-31.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -852,18 +1044,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-01.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>02.01.2024</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-02.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -873,7 +1070,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-03.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -883,28 +1083,37 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-04.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>05.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-05.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>06.01.2024</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>06.01.2024</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Service unreachable</h6>
-                                    </div>
-                                </div>
+                                <a href="#incidents-06.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -914,28 +1123,37 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-07.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>08.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-08.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.01.2024</h5></span>
                                             <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>09.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -945,7 +1163,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -955,79 +1176,102 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-12.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-13.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-14.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-15.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-16.01.2024"></a>
                             </div>                    </div>
                     <div class="api-textbar">
                         <span>90 days ago</span>
-                        <span>89% up time</span>
+                        <span>82% up time</span>
                         <span>today</span>
                     </div>
                 </article>                <article class="api-list-entry">
                     <div class="api-titlebar">
                         <h4>API 2</h4>
-                        <div class="status-bar status-fine">operational</div>
+                        <div class="status-bar status-limited">limited</div>
                     </div>
                     <div class="api-daily-status">
-                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>13.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>14.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>15.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>16.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>17.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1037,7 +1281,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1047,18 +1294,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-20.10.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>21.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1068,7 +1320,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1078,7 +1333,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1088,7 +1346,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1098,7 +1359,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-25.10.2023"></a>
                             </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1109,7 +1373,10 @@
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1119,7 +1386,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-27.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1129,7 +1399,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1139,7 +1412,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-29.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1149,18 +1425,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-30.10.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>31.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-31.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1170,7 +1451,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-01.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1180,39 +1464,51 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-02.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-03.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>05.11.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-04.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>05.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-05.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1222,17 +1518,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-06.11.2023"></a>
+                            </div>                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>07.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1242,7 +1545,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-08.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1252,7 +1558,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1262,7 +1571,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1272,30 +1584,36 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-11.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>12.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                                <a href="#incidents-12.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>13.11.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-13.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1305,7 +1623,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-14.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1315,7 +1636,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-15.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1325,7 +1649,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-16.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1335,7 +1662,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-17.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1345,7 +1675,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1355,7 +1688,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1365,7 +1701,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1375,7 +1714,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1385,18 +1727,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-22.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>23.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1406,7 +1753,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1416,7 +1766,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-25.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1426,7 +1779,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1436,7 +1792,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-27.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1446,7 +1805,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1456,7 +1818,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-29.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1466,7 +1831,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1476,7 +1844,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-01.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1486,17 +1857,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-02.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-03.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1506,7 +1884,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-04.12.2023"></a>
                             </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1517,7 +1898,10 @@
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-05.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1527,7 +1911,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-06.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1537,7 +1924,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1547,18 +1937,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-08.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>09.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1568,7 +1963,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1578,7 +1976,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1588,7 +1989,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-12.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1598,17 +2002,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-13.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>14.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-14.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1618,7 +2029,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-15.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1628,7 +2042,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-16.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1638,17 +2055,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-17.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1658,7 +2082,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1668,7 +2095,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1678,7 +2108,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1688,7 +2121,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1698,7 +2134,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1708,7 +2147,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1718,17 +2160,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-25.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>26.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1738,18 +2187,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-27.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>28.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1759,7 +2213,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-29.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1769,7 +2226,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1779,7 +2239,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-31.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1789,28 +2252,37 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-01.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>02.01.2024</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>03.01.2024</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-02.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>03.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-03.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1820,17 +2292,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-04.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>05.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-05.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1840,7 +2319,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-06.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1850,17 +2332,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-07.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>08.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-08.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1870,7 +2359,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1880,7 +2372,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1890,10 +2385,78 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-12.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-13.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-14.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-15.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-16.01.2024"></a>
                             </div>                    </div>
                     <div class="api-textbar">
                         <span>90 days ago</span>
-                        <span>87% up time</span>
+                        <span>83% up time</span>
                         <span>today</span>
                     </div>
                 </article>                <article class="api-list-entry">
@@ -1903,56 +2466,8 @@
                     </div>
                     <div class="api-daily-status">
                             <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>13.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>14.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>15.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>16.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>17.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1962,7 +2477,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1972,7 +2490,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1982,7 +2503,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -1992,7 +2516,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2002,7 +2529,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2012,29 +2542,36 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-23.10.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>24.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-24.10.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>25.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-25.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2044,7 +2581,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2054,18 +2594,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-27.10.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>28.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2075,29 +2621,36 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-29.10.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-30.10.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>31.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-31.10.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2107,7 +2660,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-01.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2117,7 +2673,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-02.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2127,7 +2686,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-03.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2137,7 +2699,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-04.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2147,7 +2712,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-05.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2157,7 +2725,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-06.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2167,7 +2738,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2177,7 +2751,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-08.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2187,7 +2764,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2197,7 +2777,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2207,17 +2790,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-11.11.2023"></a>
+                            </div>                            <div class="day-status-box status-broken">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>12.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-12.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2227,7 +2817,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-13.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2237,28 +2830,37 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-14.11.2023"></a>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>15.11.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-15.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.11.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>16.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
+                                <a href="#incidents-16.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2268,7 +2870,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-17.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2278,7 +2883,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2288,17 +2896,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-19.11.2023"></a>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>20.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2308,30 +2923,36 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-21.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>22.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-22.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>23.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2341,7 +2962,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2351,17 +2975,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-25.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>26.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2371,28 +3002,38 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-27.11.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>28.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>29.11.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-28.11.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>29.11.2023</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-29.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2402,7 +3043,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.11.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2412,7 +3056,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-01.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2422,27 +3069,39 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-02.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-03.12.2023"></a>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-04.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2452,7 +3111,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-05.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2462,7 +3124,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-06.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2472,7 +3137,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2482,18 +3150,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                                <a href="#incidents-08.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>09.12.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2503,7 +3176,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-10.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2513,7 +3189,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2523,7 +3202,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-12.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2533,7 +3215,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-13.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2543,7 +3228,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-14.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2553,7 +3241,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-15.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2563,7 +3254,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-16.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2573,7 +3267,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-17.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2583,7 +3280,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-18.12.2023"></a>
                             </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2592,9 +3292,13 @@
                                         </div>
                                         <hr>
                                             <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-19.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2604,7 +3308,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-20.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2614,7 +3321,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-21.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2624,7 +3334,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-22.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2634,7 +3347,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-23.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2644,7 +3360,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-24.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2654,38 +3373,51 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-25.12.2023"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>26.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-limited">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>27.12.2023</h5></span>
                                             <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-26.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>28.12.2023</h5></span>
+                                            <span><h5>27.12.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-27.12.2023"></a>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-28.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2695,18 +3427,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-29.12.2023"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-30.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2716,7 +3453,10 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-31.12.2023"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2726,18 +3466,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                                <a href="#incidents-01.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>02.01.2024</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-02.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2747,19 +3492,23 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                                <a href="#incidents-03.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.01.2024</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-04.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2769,27 +3518,38 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-05.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>06.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-06.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>07.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-07.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2799,28 +3559,37 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                                <a href="#incidents-08.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>09.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-limited">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>10.01.2024</h5></span>
                                             <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
+                                <a href="#incidents-09.01.2024"></a>
                             </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>10.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-10.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
@@ -2830,10 +3599,77 @@
                                         <hr>
                                     </div>
                                 </div>
+                                <a href="#incidents-11.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>12.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-12.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>13.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-13.01.2024"></a>
+                            </div>                            <div class="day-status-box status-limited">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>14.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                                <a href="#incidents-14.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>15.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-15.01.2024"></a>
+                            </div>                            <div class="day-status-box status-fine">
+                                
+                                
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>16.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                                <a href="#incidents-16.01.2024"></a>
                             </div>                    </div>
                     <div class="api-textbar">
                         <span>90 days ago</span>
-                        <span>82% up time</span>
+                        <span>83% up time</span>
                         <span>today</span>
                     </div>
                 </article>        </section>
@@ -2841,6 +3677,8 @@
                 <article>
                     <div class="api-table-title">
                         <h4>API 1</h4>
+                        <span class="info">Incidents of the last 90 days</span>
+                        <span class="info">Uptime is 82%</span>
                         <span class="status-bar status-fine">operational</span>
                     </div>
                     <table class="api-table">
@@ -2852,41 +3690,11 @@
                             </tr>
                         </thead>
                         <tbody>
-                                <tr class="marker-fine">
-                                    <th>13.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
                                 <tr class="marker-limited">
-                                    <th>14.10.2023</th>
+                                    <th>18.10.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>15.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>16.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>17.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>18.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -2919,10 +3727,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>24.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -2955,10 +3764,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>30.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -2973,10 +3783,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>02.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3003,10 +3814,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-maintenance">
                                     <th>07.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3051,10 +3863,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>15.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3069,25 +3882,25 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>18.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>19.11.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
-                                    <th>19.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>20.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3126,11 +3939,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-broken">
+                                <tr class="marker-limited">
                                     <th>27.11.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3157,24 +3970,23 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>02.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr class="marker-limited">
-                                    <th>03.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
-                                    <th>04.12.2023</th>
+                                    <th>03.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>04.12.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3213,10 +4025,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>11.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3225,10 +4038,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-maintenance">
                                     <th>13.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3297,11 +4111,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>25.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3328,10 +4141,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>30.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3346,11 +4160,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>02.01.2024</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3365,17 +4178,17 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>05.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-broken">
+                                <tr class="marker-fine">
                                     <th>06.01.2024</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3384,17 +4197,17 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>08.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>09.01.2024</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>09.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3405,6 +4218,37 @@
                                 </tr>
                                 <tr class="marker-fine">
                                     <th>11.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>12.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>13.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>14.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>15.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>16.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
@@ -3414,7 +4258,9 @@
                 </article>                <article>
                     <div class="api-table-title">
                         <h4>API 2</h4>
-                        <span class="status-bar status-fine">operational</span>
+                        <span class="info">Incidents of the last 90 days</span>
+                        <span class="info">Uptime is 83%</span>
+                        <span class="status-bar status-limited">limited</span>
                     </div>
                     <table class="api-table">
                         <thead>
@@ -3425,40 +4271,11 @@
                             </tr>
                         </thead>
                         <tbody>
-                                <tr class="marker-fine">
-                                    <th>13.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>14.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>15.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>16.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>17.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>18.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3473,11 +4290,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-fine">
                                     <th>21.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3535,11 +4351,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>31.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3554,24 +4369,24 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>03.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-maintenance">
-                                    <th>04.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
-                                    <th>05.11.2023</th>
+                                    <th>04.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>05.11.2023</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3580,10 +4395,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>07.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3610,19 +4426,16 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>12.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-broken">
+                                <tr class="marker-fine">
                                     <th>13.11.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3679,11 +4492,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>23.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3740,10 +4552,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>03.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3777,11 +4590,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-fine">
                                     <th>09.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3808,10 +4620,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>14.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3832,10 +4645,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>18.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3880,10 +4694,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>26.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3892,11 +4707,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-fine">
                                     <th>28.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3923,17 +4737,17 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
-                                    <th>02.01.2024</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                    </td>
-                                </tr>
                                 <tr class="marker-fine">
-                                    <th>03.01.2024</th>
+                                    <th>02.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>03.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3942,10 +4756,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>05.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3960,10 +4775,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>08.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -3982,6 +4798,38 @@
                                     <th>11.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>12.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>13.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>14.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>15.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>16.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                         </tbody>
@@ -3989,6 +4837,8 @@
                 </article>                <article>
                     <div class="api-table-title">
                         <h4>API 3</h4>
+                        <span class="info">Incidents of the last 90 days</span>
+                        <span class="info">Uptime is 83%</span>
                         <span class="status-bar status-fine">operational</span>
                     </div>
                     <table class="api-table">
@@ -4000,36 +4850,6 @@
                             </tr>
                         </thead>
                         <tbody>
-                                <tr class="marker-fine">
-                                    <th>13.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>14.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>15.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>16.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>17.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
                                 <tr class="marker-fine">
                                     <th>18.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
@@ -4066,18 +4886,16 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>24.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>25.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4092,11 +4910,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-limited">
                                     <th>28.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4105,18 +4923,16 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>30.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>31.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4185,10 +5001,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-broken">
                                     <th>12.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4203,17 +5020,17 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-maintenance">
                                     <th>15.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>16.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4234,10 +5051,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-maintenance">
                                     <th>20.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4246,19 +5064,16 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>22.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-fine">
                                     <th>23.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4273,10 +5088,11 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>26.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4285,17 +5101,18 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>28.11.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>29.11.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr class="marker-fine">
-                                    <th>29.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4316,16 +5133,19 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>03.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-maintenance">
                                     <th>04.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4352,11 +5172,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-broken">
+                                <tr class="marker-fine">
                                     <th>09.12.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4418,6 +5237,7 @@
                                     <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4456,23 +5276,24 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
-                                    <th>26.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
                                 <tr class="marker-limited">
-                                    <th>27.12.2023</th>
+                                    <th>26.12.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
-                                    <th>28.12.2023</th>
+                                    <th>27.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-maintenance">
+                                    <th>28.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4481,11 +5302,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-fine">
                                     <th>30.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4500,11 +5320,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-limited">
+                                <tr class="marker-fine">
                                     <th>02.01.2024</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4513,12 +5332,10 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-maintenance">
+                                <tr class="marker-fine">
                                     <th>04.01.2024</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4527,16 +5344,18 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>06.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
+                                <tr class="marker-limited">
                                     <th>07.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
@@ -4545,21 +5364,52 @@
                                     <td>
                                     </td>
                                 </tr>
-                                <tr class="marker-fine">
-                                    <th>09.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
                                 <tr class="marker-limited">
-                                    <th>10.01.2024</th>
+                                    <th>09.01.2024</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
                                 <tr class="marker-fine">
+                                    <th>10.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
                                     <th>11.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>12.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>13.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>14.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>15.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>16.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
@@ -4568,6 +5418,7 @@
                     </table>
                 </article>        </section>
         <section class="incident-log">
+            
             <h1>Incident Log</h1>
             <section>
                 <h2>Ongoing Incidents</h2>
@@ -4596,60 +5447,1053 @@
             </section>
             <section>
                 <h2>Past Incidents</h2>
-                <article>
-                    <h3>17.11.2023</h3>
-                    <article class="incident">
-                        <h4><!--<span class="incident-status status-fine">resolved</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
-                        <div class="incident-update">
-                            <h5>Resolved</h5>
-                            <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
-                            <p class="incident-update-time">17.11.2023, 18:04 UTC</p>
-                        </div>
-                        <div class="incident-update">
-                            <h5>Investigating</h5>
-                            <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
-                            <p class="incident-update-time">17.11.2023, 16:33 UTC</p>
-                        </div>
-                        <div class="incident-update">
-                            <h5>Notified</h5>
-                            <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.</span>
-                            <p class="incident-update-time">17.11.2023, 16:02 UTC</p>
-                        </div>
-                    </article>
-                </article>
-                <article>
-                    <h3>16.11.2023</h3>
-                    <p>1 incident ongoing</p>
-                </article>
-                <article>
-                    <h3>15.11.2023</h3>
-                    <p>no incidents occured</p>
-                </article>
-                <article>
-                    <h3>14.11.2023</h3>
-                    <article class="incident">
-                        <h4 class="text-maintenance"><!--<span class="incident-status status-fine">resolved</span>--><a class="text-maintenance" href="./incident.html">API 1 - Scheduled Maintenance</a></h4>
-                        <div class="incident-update">
-                            <h5>Done</h5>
-                            <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
-                            <p class="incident-update-time">14.11.2023, 11:45 UTC</p>
-                        </div>
-                        <div class="incident-update">
-                            <h5>Started</h5>
-                            <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
-                            <p class="incident-update-time">14.11.2023, 10:00 UTC</p>
-                        </div>
-                    </article>
-                </article>
-            </section>
-        </section>
+                    <article id="incidents-16.01.2024">
+                        <h3>16.01.2024</h3>
+                            <article id="incident-31" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">16.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">16.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">16.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-15.01.2024">
+                        <h3>15.01.2024</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-14.01.2024">
+                        <h3>14.01.2024</h3>
+                            <article id="incident-49" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">14.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">14.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">14.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-13.01.2024">
+                        <h3>13.01.2024</h3>
+                            <article id="incident-16" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">13.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">13.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">13.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-12.01.2024">
+                        <h3>12.01.2024</h3>
+                            <article id="incident-30" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">12.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">12.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">12.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-11.01.2024">
+                        <h3>11.01.2024</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-10.01.2024">
+                        <h3>10.01.2024</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-09.01.2024">
+                        <h3>09.01.2024</h3>
+                            <article id="incident-15" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">09.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">09.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">09.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-48" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">09.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">09.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">09.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-08.01.2024">
+                        <h3>08.01.2024</h3>
+                            <article id="incident-29" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">08.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">08.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">08.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-07.01.2024">
+                        <h3>07.01.2024</h3>
+                            <article id="incident-47" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">07.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">07.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">07.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-06.01.2024">
+                        <h3>06.01.2024</h3>
+                            <article id="incident-46" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">06.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">06.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">06.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-05.01.2024">
+                        <h3>05.01.2024</h3>
+                            <article id="incident-14" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">05.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">05.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">05.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-28" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">05.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">05.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">05.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-04.01.2024">
+                        <h3>04.01.2024</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-03.01.2024">
+                        <h3>03.01.2024</h3>
+                            <article id="incident-27" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">03.01.2024 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">03.01.2024 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">03.01.2024 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-02.01.2024">
+                        <h3>02.01.2024</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-01.01.2024">
+                        <h3>01.01.2024</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-31.12.2023">
+                        <h3>31.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-30.12.2023">
+                        <h3>30.12.2023</h3>
+                            <article id="incident-13" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 1</span>--><a class="text-broken" href="./incident.html">API 1 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">30.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">30.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">30.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-29.12.2023">
+                        <h3>29.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-28.12.2023">
+                        <h3>28.12.2023</h3>
+                            <article id="incident-45" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">28.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">28.12.2023 08:30:07</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-27.12.2023">
+                        <h3>27.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-26.12.2023">
+                        <h3>26.12.2023</h3>
+                            <article id="incident-26" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">26.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">26.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">26.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-44" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">26.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">26.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">26.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-25.12.2023">
+                        <h3>25.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-24.12.2023">
+                        <h3>24.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-23.12.2023">
+                        <h3>23.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-22.12.2023">
+                        <h3>22.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-21.12.2023">
+                        <h3>21.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-20.12.2023">
+                        <h3>20.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-19.12.2023">
+                        <h3>19.12.2023</h3>
+                            <article id="incident-42" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">19.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">19.12.2023 08:30:07</p>
+                                    </div>
+                            </article>                            <article id="incident-43" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">19.12.2023 13:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">19.12.2023 15:30:07</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-18.12.2023">
+                        <h3>18.12.2023</h3>
+                            <article id="incident-25" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">18.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">18.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">18.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-17.12.2023">
+                        <h3>17.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-16.12.2023">
+                        <h3>16.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-15.12.2023">
+                        <h3>15.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-14.12.2023">
+                        <h3>14.12.2023</h3>
+                            <article id="incident-24" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">14.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">14.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">14.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-13.12.2023">
+                        <h3>13.12.2023</h3>
+                            <article id="incident-12" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 1</span>--><a class="text-maintenance" href="./incident.html">API 1 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">13.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">13.12.2023 08:30:07</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-12.12.2023">
+                        <h3>12.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-11.12.2023">
+                        <h3>11.12.2023</h3>
+                            <article id="incident-11" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 1</span>--><a class="text-broken" href="./incident.html">API 1 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">11.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">11.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">11.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-10.12.2023">
+                        <h3>10.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-09.12.2023">
+                        <h3>09.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-08.12.2023">
+                        <h3>08.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-07.12.2023">
+                        <h3>07.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-06.12.2023">
+                        <h3>06.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-05.12.2023">
+                        <h3>05.12.2023</h3>
+                            <article id="incident-23" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">05.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">05.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">05.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-04.12.2023">
+                        <h3>04.12.2023</h3>
+                            <article id="incident-10" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">04.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">04.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">04.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-40" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">04.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">04.12.2023 08:30:07</p>
+                                    </div>
+                            </article>                            <article id="incident-41" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">04.12.2023 13:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">04.12.2023 15:30:07</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-03.12.2023">
+                        <h3>03.12.2023</h3>
+                            <article id="incident-22" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">03.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">03.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">03.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-39" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">03.12.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">03.12.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">03.12.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-02.12.2023">
+                        <h3>02.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-01.12.2023">
+                        <h3>01.12.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-30.11.2023">
+                        <h3>30.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-29.11.2023">
+                        <h3>29.11.2023</h3>
+                            <article id="incident-37" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">29.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">29.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">29.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-38" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">29.11.2023 13:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">29.11.2023 15:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">29.11.2023 17:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-28.11.2023">
+                        <h3>28.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-27.11.2023">
+                        <h3>27.11.2023</h3>
+                            <article id="incident-9" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">27.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">27.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">27.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-26.11.2023">
+                        <h3>26.11.2023</h3>
+                            <article id="incident-36" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">26.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">26.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">26.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-25.11.2023">
+                        <h3>25.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-24.11.2023">
+                        <h3>24.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-23.11.2023">
+                        <h3>23.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-22.11.2023">
+                        <h3>22.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-21.11.2023">
+                        <h3>21.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-20.11.2023">
+                        <h3>20.11.2023</h3>
+                            <article id="incident-7" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">20.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">20.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">20.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-8" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">20.11.2023 13:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">20.11.2023 15:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">20.11.2023 17:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-35" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">20.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">20.11.2023 08:30:07</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-19.11.2023">
+                        <h3>19.11.2023</h3>
+                            <article id="incident-6" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">19.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">19.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">19.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-18.11.2023">
+                        <h3>18.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-17.11.2023">
+                        <h3>17.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-16.11.2023">
+                        <h3>16.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-15.11.2023">
+                        <h3>15.11.2023</h3>
+                            <article id="incident-5" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">15.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">15.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">15.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-34" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 3</span>--><a class="text-maintenance" href="./incident.html">API 3 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">15.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">15.11.2023 08:30:07</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-14.11.2023">
+                        <h3>14.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-13.11.2023">
+                        <h3>13.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-12.11.2023">
+                        <h3>12.11.2023</h3>
+                            <article id="incident-33" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 3</span>--><a class="text-broken" href="./incident.html">API 3 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">12.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">12.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">12.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-11.11.2023">
+                        <h3>11.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-10.11.2023">
+                        <h3>10.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-09.11.2023">
+                        <h3>09.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-08.11.2023">
+                        <h3>08.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-07.11.2023">
+                        <h3>07.11.2023</h3>
+                            <article id="incident-4" class="incident">
+                                <h4><!--<span class="incident-api status-maintenance">API 1</span>--><a class="text-maintenance" href="./incident.html">API 1 - Scheduled Maintenance</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Done</h5>
+                                        <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
+                                        <p class="incident-update-time">07.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Started</h5>
+                                        <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
+                                        <p class="incident-update-time">07.11.2023 08:30:07</p>
+                                    </div>
+                            </article>                            <article id="incident-21" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 2</span>--><a class="text-broken" href="./incident.html">API 2 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">07.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">07.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">07.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-06.11.2023">
+                        <h3>06.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-05.11.2023">
+                        <h3>05.11.2023</h3>
+                            <article id="incident-20" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">05.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">05.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">05.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-04.11.2023">
+                        <h3>04.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-03.11.2023">
+                        <h3>03.11.2023</h3>
+                            <article id="incident-19" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">03.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">03.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">03.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-02.11.2023">
+                        <h3>02.11.2023</h3>
+                            <article id="incident-3" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 1</span>--><a class="text-broken" href="./incident.html">API 1 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">02.11.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">02.11.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">02.11.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-01.11.2023">
+                        <h3>01.11.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-31.10.2023">
+                        <h3>31.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-30.10.2023">
+                        <h3>30.10.2023</h3>
+                            <article id="incident-2" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 1</span>--><a class="text-broken" href="./incident.html">API 1 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">30.10.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">30.10.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">30.10.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-29.10.2023">
+                        <h3>29.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-28.10.2023">
+                        <h3>28.10.2023</h3>
+                            <article id="incident-32" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 3</span>--><a class="text-limited" href="./incident.html">API 3 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">28.10.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">28.10.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">28.10.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-27.10.2023">
+                        <h3>27.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-26.10.2023">
+                        <h3>26.10.2023</h3>
+                            <article id="incident-18" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 2</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">26.10.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">26.10.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">26.10.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-25.10.2023">
+                        <h3>25.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-24.10.2023">
+                        <h3>24.10.2023</h3>
+                            <article id="incident-1" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">24.10.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">24.10.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">24.10.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>                    <article id="incidents-23.10.2023">
+                        <h3>23.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-22.10.2023">
+                        <h3>22.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-21.10.2023">
+                        <h3>21.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-20.10.2023">
+                        <h3>20.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-19.10.2023">
+                        <h3>19.10.2023</h3>
+                        No incidents occured
+                    </article>                    <article id="incidents-18.10.2023">
+                        <h3>18.10.2023</h3>
+                            <article id="incident-0" class="incident">
+                                <h4><!--<span class="incident-api status-limited">API 1</span>--><a class="text-limited" href="./incident.html">API 1 - Sporadic erroneous rate limiting</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Resolved</h5>
+                                        <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
+                                        <p class="incident-update-time">18.10.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
+                                        <p class="incident-update-time">18.10.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting</span>
+                                        <p class="incident-update-time">18.10.2023 10:43:30</p>
+                                    </div>
+                            </article>                            <article id="incident-17" class="incident">
+                                <h4><!--<span class="incident-api status-broken">API 2</span>--><a class="text-broken" href="./incident.html">API 2 - Service unreachable</a></h4>
+                                    <div class="incident-update">
+                                        <h5>Identified</h5>
+                                        <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                                        <p class="incident-update-time">18.10.2023 06:16:44</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Investigating</h5>
+                                        <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                                        <p class="incident-update-time">18.10.2023 08:30:07</p>
+                                    </div>
+                                    <div class="incident-update">
+                                        <h5>Notified</h5>
+                                        <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                                        <p class="incident-update-time">18.10.2023 10:43:30</p>
+                                    </div>
+                            </article>                    </article>            </section>        </section>
     </main>
     <footer>
         <div id="accessibility-options">
             <h5>Accessibility options:</h5>
             <input id="colorBlindMode" type="checkbox" onclick="switchColorMode()"></input><label for="colorBlindMode">Colors for colorblind</label>
-            <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
-            <input id="tableHideFineDays" type="checkbox" onclick="switchTableHideOperationalDays()" disabled></input><label id="tableHideFineDaysLabel" class="disabled" for="tableHideFineDays">Use table display</label>
             <input id="increasedTextSizeMode" type="checkbox" onclick="switchTextSize()"></input><label for="increasedTextSizeMode">Increased text size</label>
         </div>
         <div id="other-links">

--- a/html-prototype/index.html
+++ b/html-prototype/index.html
@@ -38,30 +38,21 @@
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>12.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
                                             <span><h5>13.10.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>14.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -114,15 +105,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>20.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -175,15 +165,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>26.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -206,15 +195,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>29.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -227,15 +215,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>31.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -258,15 +245,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -309,16 +295,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>08.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -351,26 +335,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>12.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>13.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -424,14 +406,16 @@
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>19.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -504,25 +488,25 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-broken">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>27.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>28.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -545,15 +529,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>01.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-limited">
@@ -567,14 +550,15 @@
                                             <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -607,15 +591,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>07.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -688,15 +671,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>15.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -729,15 +711,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>19.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -790,14 +771,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>25.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -860,15 +842,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>01.01.2024</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-limited">
@@ -892,15 +873,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.01.2024</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -913,32 +893,22 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-broken">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>06.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-maintenance">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>07.01.2024</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>08.01.2024</h5></span>
+                                            <span><h5>07.01.2024</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
@@ -948,11 +918,21 @@
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>09.01.2024</h5></span>
+                                            <span><h5>08.01.2024</h5></span>
                                             <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
                                             <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>09.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -965,32 +945,32 @@
                                         <hr>
                                     </div>
                                 </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
                             </div>                    </div>
                     <div class="api-textbar">
                         <span>90 days ago</span>
-                        <span>1.28% up time</span>
+                        <span>89% up time</span>
                         <span>today</span>
                     </div>
                 </article>                <article class="api-list-entry">
                     <div class="api-titlebar">
                         <h4>API 2</h4>
-                        <div class="status-bar status-broken">broken</div>
+                        <div class="status-bar status-fine">operational</div>
                     </div>
                     <div class="api-daily-status">
                             <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>12.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
                                             <span><h5>13.10.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
@@ -1007,15 +987,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>15.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1028,15 +1007,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>17.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1069,26 +1047,25 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>21.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
                             </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>22.10.2023</h5></span>
+                                            <span><h5>21.10.2023</h5></span>
                                             <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
                                             <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>22.10.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1172,14 +1149,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>31.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1212,14 +1190,16 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1242,37 +1222,34 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>07.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>08.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>09.11.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1285,35 +1262,37 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>11.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>12.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-broken">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>13.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1346,26 +1325,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>17.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1388,15 +1365,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>21.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1409,14 +1385,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>23.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1439,27 +1416,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>26.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>27.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1492,15 +1466,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>01.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1513,15 +1486,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.12.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1534,14 +1506,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>05.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1564,27 +1537,25 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>08.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>09.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1657,38 +1628,34 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>17.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.12.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>19.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1711,26 +1678,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>22.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>23.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1763,25 +1728,25 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>27.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
                             </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>28.12.2023</h5></span>
+                                            <span><h5>27.12.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>28.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1804,36 +1769,35 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>31.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-maintenance">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>01.01.2024</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>02.01.2024</h5></span>
+                                            <span><h5>01.01.2024</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>02.01.2024</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1866,15 +1830,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>06.01.2024</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -1907,21 +1870,30 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>10.01.2024</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.01.2024</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
                                     </div>
                                 </div>
                             </div>                    </div>
                     <div class="api-textbar">
                         <span>90 days ago</span>
-                        <span>1.2% up time</span>
+                        <span>87% up time</span>
                         <span>today</span>
                     </div>
                 </article>                <article class="api-list-entry">
@@ -1934,16 +1906,6 @@
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>12.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
-                                        </div>
-                                        <hr>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-fine">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
                                             <span><h5>13.10.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
@@ -1990,15 +1952,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.10.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2011,15 +1972,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>20.10.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2052,24 +2012,26 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>24.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>25.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2082,15 +2044,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>27.10.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-maintenance">
@@ -2114,24 +2075,26 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>31.10.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2154,37 +2117,34 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-broken">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>03.11.2023</h5></span>
-                                            <div class="status-bar status-broken">broken</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>05.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2257,15 +2217,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>13.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2288,14 +2247,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>16.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2308,38 +2268,34 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>18.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>19.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>20.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2352,24 +2308,27 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>22.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>23.11.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2382,15 +2341,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>25.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2413,15 +2371,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>28.11.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2434,15 +2392,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.11.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2475,16 +2432,14 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2527,14 +2482,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-broken">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>09.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-broken">broken</div>
                                         </div>
                                         <hr>
+                                            <h6>Service unreachable</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2597,48 +2553,45 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>16.12.2023</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-maintenance">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>17.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
-                                            <h6>Scheduled Maintenance</h6>
-                                    </div>
-                                </div>
-                            </div>                            <div class="day-status-box status-maintenance">
-                                <div class="tooltip-wrap">
-                                    <div class="tooltip-content">
-                                        <div class="tooltip-title">
-                                            <span><h5>18.12.2023</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
-                                        </div>
-                                        <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
-                                            <span><h5>19.12.2023</h5></span>
+                                            <span><h5>17.12.2023</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>18.12.2023</h5></span>
+                                            <div class="status-bar status-fine">operational</div>
+                                        </div>
+                                        <hr>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-maintenance">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>19.12.2023</h5></span>
+                                            <div class="status-bar status-maintenance">maintenance</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2711,14 +2664,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>27.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2741,14 +2695,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>30.12.2023</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2771,14 +2726,15 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>02.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-limited">limited</div>
                                         </div>
                                         <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2791,14 +2747,16 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-maintenance">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>04.01.2024</h5></span>
-                                            <div class="status-bar status-fine">operational</div>
+                                            <div class="status-bar status-maintenance">maintenance</div>
                                         </div>
                                         <hr>
+                                            <h6>Scheduled Maintenance</h6>
+                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2821,27 +2779,24 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-limited">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>07.01.2024</h5></span>
-                                            <div class="status-bar status-limited">limited</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Sporadic erroneous rate limiting</h6>
-                                            <h6>Sporadic erroneous rate limiting</h6>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-maintenance">
+                            </div>                            <div class="day-status-box status-fine">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>08.01.2024</h5></span>
-                                            <div class="status-bar status-maintenance">maintenance</div>
+                                            <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
-                                            <h6>Scheduled Maintenance</h6>
                                     </div>
                                 </div>
                             </div>                            <div class="day-status-box status-fine">
@@ -2854,11 +2809,22 @@
                                         <hr>
                                     </div>
                                 </div>
-                            </div>                            <div class="day-status-box status-fine">
+                            </div>                            <div class="day-status-box status-limited">
                                 <div class="tooltip-wrap">
                                     <div class="tooltip-content">
                                         <div class="tooltip-title">
                                             <span><h5>10.01.2024</h5></span>
+                                            <div class="status-bar status-limited">limited</div>
+                                        </div>
+                                        <hr>
+                                            <h6>Sporadic erroneous rate limiting</h6>
+                                    </div>
+                                </div>
+                            </div>                            <div class="day-status-box status-fine">
+                                <div class="tooltip-wrap">
+                                    <div class="tooltip-content">
+                                        <div class="tooltip-title">
+                                            <span><h5>11.01.2024</h5></span>
                                             <div class="status-bar status-fine">operational</div>
                                         </div>
                                         <hr>
@@ -2867,7 +2833,7 @@
                             </div>                    </div>
                     <div class="api-textbar">
                         <span>90 days ago</span>
-                        <span>1.28% up time</span>
+                        <span>82% up time</span>
                         <span>today</span>
                     </div>
                 </article>        </section>
@@ -2886,580 +2852,569 @@
                             </tr>
                         </thead>
                         <tbody>
-                                <tr>
-                                    <th>12.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>14.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>28.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>30.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>31.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>02.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>03.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>09.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>11.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>12.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>18.11.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>19.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-broken">
                                     <th>27.11.2023</th>
+                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>28.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
-                                    <th>28.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>30.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>02.12.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>03.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>09.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>11.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>12.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>25.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>28.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>30.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>31.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.01.2024</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>02.01.2024</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>03.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.01.2024</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-broken">
                                     <th>06.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.01.2024</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>08.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
-                                    <th>09.01.2024</th>
+                                <tr class="marker-limited">
+                                    <th>08.01.2024</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
+                                    <th>09.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
                                     <th>10.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                            
+                                <tr class="marker-fine">
+                                    <th>11.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
                         </tbody>
                     </table>
                 </article>                <article>
                     <div class="api-table-title">
                         <h4>API 2</h4>
-                        <span class="status-bar status-broken">broken</span>
+                        <span class="status-bar status-fine">operational</span>
                     </div>
                     <table class="api-table">
                         <thead>
@@ -3470,584 +3425,565 @@
                             </tr>
                         </thead>
                         <tbody>
-                                <tr>
-                                    <th>12.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>21.10.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>22.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
-                                    <th>22.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                    </td>
-                                </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>26.10.2023</th>
                                     <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>28.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>30.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>31.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>02.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>03.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>04.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>09.11.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>11.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>12.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-broken">
                                     <th>13.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>23.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>28.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>30.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>02.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>03.12.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>05.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>09.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>11.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>12.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.12.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>28.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>29.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>30.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>31.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>01.01.2024</th>
                                     <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
-                                    <th>02.01.2024</th>
+                                <tr class="marker-fine">
+                                    <th>29.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
+                                    <th>30.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>31.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>01.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-maintenance">
+                                    <th>02.01.2024</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
                                     <th>03.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.01.2024</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>09.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.01.2024</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                            
+                                <tr class="marker-fine">
+                                    <th>11.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
                         </tbody>
                     </table>
                 </article>                <article>
@@ -4064,577 +4000,570 @@
                             </tr>
                         </thead>
                         <tbody>
-                                <tr>
-                                    <th>12.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.10.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.10.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>24.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>25.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.10.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>28.10.2023</th>
                                     <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.10.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>30.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>31.10.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>02.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>03.11.2023</th>
-                                    <td><span class="status-bar status-broken">broken</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>09.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>11.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>12.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>16.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>17.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>18.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>19.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>20.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>22.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>23.11.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>27.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>28.11.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.11.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>30.11.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>01.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>02.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>03.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>04.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>05.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>06.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>07.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>08.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-broken">
                                     <th>09.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-broken">broken</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Service unreachable</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>10.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>11.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>12.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>13.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>14.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>15.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>16.12.2023</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>17.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>18.12.2023</th>
-                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>19.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
+                                    <th>17.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>18.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-maintenance">
+                                    <th>19.12.2023</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
                                     <th>20.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>21.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>22.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>23.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>24.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>25.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>26.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>27.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td><span class="status-bar status-limited">limited</span></td>
                                     <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>28.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
                                     <th>29.12.2023</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-maintenance">
                                     <th>30.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>31.12.2023</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>01.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>02.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>03.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>04.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>05.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>06.01.2024</th>
-                                    <td><span class="status-bar status-fine">operational</span></td>
-                                    <td>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>07.01.2024</th>
-                                    <td><span class="status-bar status-limited">limited</span></td>
-                                    <td>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>08.01.2024</th>
                                     <td><span class="status-bar status-maintenance">maintenance</span></td>
                                     <td>
                                             <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-fine">
+                                    <th>31.12.2023</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>01.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-limited">
+                                    <th>02.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>03.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-maintenance">
+                                    <th>04.01.2024</th>
+                                    <td><span class="status-bar status-maintenance">maintenance</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                            <a style="display:block;" href="./incident.html">Scheduled Maintenance</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>05.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>06.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>07.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>08.01.2024</th>
+                                    <td><span class="status-bar status-fine">operational</span></td>
+                                    <td>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
                                     <th>09.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                                <tr>
+                                <tr class="marker-limited">
                                     <th>10.01.2024</th>
+                                    <td><span class="status-bar status-limited">limited</span></td>
+                                    <td>
+                                            <a style="display:block;" href="./incident.html">Sporadic erroneous rate limiting</a>
+                                    </td>
+                                </tr>
+                                <tr class="marker-fine">
+                                    <th>11.01.2024</th>
                                     <td><span class="status-bar status-fine">operational</span></td>
                                     <td>
                                     </td>
                                 </tr>
-                            
                         </tbody>
                     </table>
                 </article>        </section>
@@ -4720,6 +4649,7 @@
             <h5>Accessibility options:</h5>
             <input id="colorBlindMode" type="checkbox" onclick="switchColorMode()"></input><label for="colorBlindMode">Colors for colorblind</label>
             <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
+            <input id="tableHideFineDays" type="checkbox" onclick="switchTableHideOperationalDays()" disabled></input><label id="tableHideFineDaysLabel" class="disabled" for="tableHideFineDays">Use table display</label>
             <input id="increasedTextSizeMode" type="checkbox" onclick="switchTextSize()"></input><label for="increasedTextSizeMode">Increased text size</label>
         </div>
         <div id="other-links">

--- a/html-prototype/statuspage.js
+++ b/html-prototype/statuspage.js
@@ -1,7 +1,10 @@
 
 const CB_COLORBLIND = "colorBlindMode";
 const CB_TABLE = "tableMode";
+const CB_TABLE_HIDE_FINE = "tableHideFineDays";
 const CB_INCREASED_TEXT = "increasedTextSizeMode";
+
+const LBL_TABLE_HIDE_FINE = "tableHideFineDaysLabel";
 
 let themeColors = {}
 
@@ -33,6 +36,10 @@ function init() {
         document.getElementById(CB_TABLE).checked = true;
         switchApiDisplay();
     }
+    if (document.cookie.match("AccessibilityTableHideFine=true")) {
+        document.getElementById(CB_TABLE).checked = true;
+        switchTableHideOperationalDays();
+    }
 }
 
 function switchColorMode() {
@@ -43,7 +50,7 @@ function switchColorMode() {
         r.style.setProperty("--fine-color", "#8CE05D");
         r.style.setProperty("--limited-color", "#5D3A9B");
         r.style.setProperty("--broken-color", "#D62C13");
-        document.cookie = "AccessibilityColorblind=true";
+        document.cookie = "AccessibilityColorblind=true; SameSite=Strict";
         // Switch to colors for colorblind
     } else {
         // Re-establish ordinary colors
@@ -52,7 +59,7 @@ function switchColorMode() {
         r.style.setProperty("--fine-color", themeColors["--fine-color"]);
         r.style.setProperty("--limited-color", themeColors["--limited-color"]);
         r.style.setProperty("--broken-color", themeColors["--broken-color"]);
-        document.cookie = "AccessibilityColorblind=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+        document.cookie = "AccessibilityColorblind=; expires=Thu, 01 Jan 1970 00:00:00 UTC; SameSite=Strict";
     }
 }
 
@@ -61,11 +68,11 @@ function switchTextSize() {
     if (checkbox.checked) {
         let r = document.querySelector(":root");
         r.style.setProperty("--default-text-size", TextSizes.Increased);
-        document.cookie = "AccessibilityIncreasedText=true";
+        document.cookie = "AccessibilityIncreasedText=true; SameSite=Strict";
     } else {
         let r = document.querySelector(":root");
         r.style.setProperty("--default-text-size", TextSizes.Default);
-        document.cookie = "AccessibilityIncreasedText=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+        document.cookie = "AccessibilityIncreasedText=; expires=Thu, 01 Jan 1970 00:00:00 UTC; SameSite=Strict";
     }
 }
 
@@ -73,13 +80,48 @@ function switchApiDisplay() {
     let checkbox = document.getElementById(CB_TABLE);
     let list = document.getElementById("api-list");
     let table = document.getElementById("api-table");
+    let hide = document.getElementById(CB_TABLE_HIDE_FINE);
     if (checkbox.checked) {
         list.classList.add("hidden");
         table.classList.remove("hidden");
-        document.cookie = "AccessibilityUseTable=true";
+        enableTableHide(true);
+        document.cookie = "AccessibilityUseTable=true; SameSite=Strict";
     } else {
         table.classList.add("hidden");
         list.classList.remove("hidden");
-        document.cookie = "AccessibilityUseTable=; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+        enableTableHide(false);
+        document.cookie = "AccessibilityUseTable=; expires=Thu, 01 Jan 1970 00:00:00 UTC; SameSite=Strict";
+    }
+}
+
+function enableTableHide(enabled) {
+    let hide = document.getElementById(CB_TABLE_HIDE_FINE);
+    let label = document.getElementById(LBL_TABLE_HIDE_FINE);
+    hide.disabled = !enabled;
+    if (enabled) {
+        label.classList.remove("disabled");
+    } else {
+        label.classList.add("disabled");
+    }
+}
+
+function switchTableHideOperationalDays() {
+    let tableEnabled = document.getElementById(CB_TABLE).checked;
+    let checkbox = document.getElementById(CB_TABLE_HIDE_FINE);
+    let table = document.getElementById("api-table");
+    if (tableEnabled) {
+        if (checkbox.checked) {
+            elements = table.getElementsByClassName("marker-fine");
+            for (i = 0; i < elements.length; i++) {
+                elements[i].classList.add("hidden");
+            }
+            document.cookie = "AccessibilityTableHideFine=true; SameSite=Strict";
+        } else {
+            elements = table.getElementsByClassName("marker-fine");
+            for (i = 0; i < elements.length; i++) {
+                elements[i].classList.remove("hidden");
+            }
+            document.cookie = "AccessibilityTableHideFine=; expires=Thu, 01 Jan 1970 00:00:00 UTC; SameSite=Strict";
+        }
     }
 }

--- a/html-prototype/styles.css
+++ b/html-prototype/styles.css
@@ -194,12 +194,25 @@ a:hover {
 
 header {
     width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
     padding: 5px 0 5px 0;
     background-color: var(--main-bg-color);
     margin-top: 1rem;
+}
+
+header div {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: .75rem;
+}
+
+header div:last-of-type {
+    margin-bottom: 0;
+}
+
+header input {
+    margin-left: 1rem;
 }
 
 footer {
@@ -404,6 +417,10 @@ footer div input {
     font-size: 1.25rem;
 }
 
+.api-table-title .info {
+    color: var(--faint-text-color);
+}
+
 .api-table-title .status-bar {
     font-size: 1rem;
 }
@@ -496,14 +513,20 @@ td, th {
 .incident {
     margin-left: .5rem;
 }
+
+.incident h4 {
+    margin: .75rem 0;
+}
+
 .incident .incident-start-date {
     color: var(--faint-text-color);
     font-size: 0.75rem;
-    margin-top: -1.25rem;
+    margin-top: -.75rem;
 }
 
-.incident-status {
+.incident-api {
     color: var(--main-bg-color);
+    background-color: var(--unknown-color);
     margin-right: .75rem;
     padding: .25rem;
     border-radius: var(--bar-border-radius);
@@ -512,7 +535,7 @@ td, th {
 }
 
 .incident-update {
-
+    margin-left: 1rem;
 }
 
 .incident-update-content {

--- a/html-prototype/styles.css
+++ b/html-prototype/styles.css
@@ -199,6 +199,7 @@ header {
     justify-content: space-between;
     padding: 5px 0 5px 0;
     background-color: var(--main-bg-color);
+    margin-top: 1rem;
 }
 
 footer {
@@ -396,10 +397,15 @@ footer div input {
     justify-content: space-between;
     padding: 5px 0 5px 0;
     align-items: center;
+    margin-top: 2rem;
 }
 
 .api-table-title h4 {
     font-size: 1.25rem;
+}
+
+.api-table-title .status-bar {
+    font-size: 1rem;
 }
 
 #api-table article {

--- a/html-prototype/styles.css
+++ b/html-prototype/styles.css
@@ -537,3 +537,7 @@ td, th {
 .hidden {
     display: none;
 }
+
+.disabled {
+    color: var(--faint-text-color);
+}

--- a/html-prototype/templates/api-status-box.mustache
+++ b/html-prototype/templates/api-status-box.mustache
@@ -1,4 +1,6 @@
 <div class="day-status-box status-{{ status }}">
+    
+    
     <div class="tooltip-wrap">
         <div class="tooltip-content">
             <div class="tooltip-title">
@@ -11,4 +13,5 @@
             {{/incidents}}
         </div>
     </div>
+    <a href="#incidents-{{ date }}"></a>
 </div>

--- a/html-prototype/templates/api-table.mustache
+++ b/html-prototype/templates/api-table.mustache
@@ -13,7 +13,7 @@
         </thead>
         <tbody>
             {{# days }}
-                <tr>
+                <tr class="marker-{{ status }}">
                     <th>{{ date }}</th>
                     <td><span class="status-bar status-{{ status }}">{{ status-text }}</span></td>
                     <td>
@@ -23,7 +23,6 @@
                     </td>
                 </tr>
             {{/ days }}
-            
         </tbody>
     </table>
 </article>

--- a/html-prototype/templates/api-table.mustache
+++ b/html-prototype/templates/api-table.mustache
@@ -1,6 +1,8 @@
 <article>
     <div class="api-table-title">
         <h4>{{ name }}</h4>
+        <span class="info">Incidents of the last 90 days</span>
+        <span class="info">Uptime is {{ uptime }}%</span>
         <span class="status-bar status-{{ status }}">{{ status-text }}</span>
     </div>
     <table class="api-table">

--- a/html-prototype/templates/incident-log.mustache
+++ b/html-prototype/templates/incident-log.mustache
@@ -1,0 +1,33 @@
+
+<h1>Incident Log</h1>
+<section>
+    <h2>Ongoing Incidents</h2>
+    <article>
+        <h3>17.11.2023</h3>
+        <article class="incident">
+            <h4><!--<span class="incident-status status-broken">ongoing</span>--><a class="text-broken" href="./incident.html">API 3 - Service unreachable</a></h4>
+            <p class="incident-start-date">since 16.11.2023</p>
+            <section class="incident-update">
+                <h5>Identified</h5>
+                <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
+                <p class="incident-update-time">17.11.2023, 15:07 UTC</p>
+            </section>
+            <section class="incident-update">
+                <h5>Investigating</h5>
+                <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
+                <p class="incident-update-time">16.11.2023, 17:22 UTC</p>
+            </section>
+            <section class="incident-update">
+                <h5>Notified</h5>
+                <span class="incident-update-content"> - We have received an automated warning about the service.</span>
+                <p class="incident-update-time">16.11.2023, 14:41 UTC</p>
+            </section>
+        </article>
+    </article>
+</section>
+<section>
+    <h2>Past Incidents</h2>
+    {{# incidents-by-day }}
+        {{> incidents-by-day }}
+    {{/ incidents-by-day }}
+</section>

--- a/html-prototype/templates/incident.mustache
+++ b/html-prototype/templates/incident.mustache
@@ -1,0 +1,10 @@
+<article id="incident-{{ id }}" class="incident">
+    <h4><!--<span class="incident-api status-{{ severity }}">{{ api }}</span>--><a class="text-{{ severity }}" href="./incident.html">{{ api }} - {{ title }}</a></h4>
+    {{# updates }}
+        <div class="incident-update">
+            <h5>{{ title }}</h5>
+            <span class="incident-update-content"> - {{ text }}</span>
+            <p class="incident-update-time">{{ datetime }}</p>
+        </div>
+    {{/ updates }}
+</article>

--- a/html-prototype/templates/incidents-by-day.mustache
+++ b/html-prototype/templates/incidents-by-day.mustache
@@ -1,0 +1,9 @@
+<article id="incidents-{{ date }}">
+    <h3>{{ date }}</h3>
+   {{^ incidents }}
+    No incidents occured
+   {{/ incidents }}
+    {{# incidents }}
+        {{> incident }}
+    {{/ incidents }}
+</article>

--- a/html-prototype/templates/page.mustache
+++ b/html-prototype/templates/page.mustache
@@ -119,6 +119,7 @@
             <h5>Accessibility options:</h5>
             <input id="colorBlindMode" type="checkbox" onclick="switchColorMode()"></input><label for="colorBlindMode">Colors for colorblind</label>
             <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
+            <input id="tableHideFineDays" type="checkbox" onclick="switchTableHideOperationalDays()" disabled></input><label id="tableHideFineDaysLabel" class="disabled" for="tableHideFineDays">Use table display</label>
             <input id="increasedTextSizeMode" type="checkbox" onclick="switchTextSize()"></input><label for="increasedTextSizeMode">Increased text size</label>
         </div>
         <div id="other-links">

--- a/html-prototype/templates/page.mustache
+++ b/html-prototype/templates/page.mustache
@@ -11,8 +11,17 @@
 
 <body onload="init()">
     <header>
-        <img alt="" title="SCS Project" src="assets/scs-logo.svg">
-        <button type="button" class="subscribe-btn">Subscribe to Updates</button>
+        <div>
+            <img alt="" title="SCS Project" src="assets/scs-logo.svg">
+            <button type="button" class="subscribe-btn">Subscribe to Updates</button>
+        </div>
+        <div>
+            <a href="#accessibility-options">Skip to accessibility options</a>
+            <span>
+                <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
+                <input id="tableHideFineDays" type="checkbox" onclick="switchTableHideOperationalDays()" disabled></input><label id="tableHideFineDaysLabel" class="disabled" for="tableHideFineDays">Hide operational days (table display only)</label>
+            </span>
+        </div>
     </header>
     <main>
         <div class="status-bar status-fine">
@@ -38,88 +47,13 @@
             {{/ apis }}
         </section>
         <section class="incident-log">
-            <h1>Incident Log</h1>
-            <section>
-                <h2>Ongoing Incidents</h2>
-                <article>
-                    <h3>17.11.2023</h3>
-                    <article class="incident">
-                        <h4><!--<span class="incident-status status-broken">ongoing</span>--><a class="text-broken" href="./incident.html">API 3 - Service unreachable</a></h4>
-                        <p class="incident-start-date">since 16.11.2023</p>
-                        <section class="incident-update">
-                            <h5>Identified</h5>
-                            <span class="incident-update-content"> - We have identified the root cause of the problem and are working on a workaround. A final fix will be scheduled for the next maintenance period.</span>
-                            <p class="incident-update-time">17.11.2023, 15:07 UTC</p>
-                        </section>
-                        <section class="incident-update">
-                            <h5>Investigating</h5>
-                            <span class="incident-update-content"> - We have determined that the service itself is unreachable. The server running it seems fine.</span>
-                            <p class="incident-update-time">16.11.2023, 17:22 UTC</p>
-                        </section>
-                        <section class="incident-update">
-                            <h5>Notified</h5>
-                            <span class="incident-update-content"> - We have received an automated warning about the service.</span>
-                            <p class="incident-update-time">16.11.2023, 14:41 UTC</p>
-                        </section>
-                    </article>
-                </article>
-            </section>
-            <section>
-                <h2>Past Incidents</h2>
-                <article>
-                    <h3>17.11.2023</h3>
-                    <article class="incident">
-                        <h4><!--<span class="incident-status status-fine">resolved</span>--><a class="text-limited" href="./incident.html">API 2 - Sporadic erroneous rate limiting</a></h4>
-                        <div class="incident-update">
-                            <h5>Resolved</h5>
-                            <span class="incident-update-content"> - We have corrected the faulty rate limiting configuration.</span>
-                            <p class="incident-update-time">17.11.2023, 18:04 UTC</p>
-                        </div>
-                        <div class="incident-update">
-                            <h5>Investigating</h5>
-                            <span class="incident-update-content"> - Our internal monitoring has confirmed these reports.</span>
-                            <p class="incident-update-time">17.11.2023, 16:33 UTC</p>
-                        </div>
-                        <div class="incident-update">
-                            <h5>Notified</h5>
-                            <span class="incident-update-content"> - We were notified that API 2 is sometimes unreachable due to rate limiting, even though the client is below their allotted quota.</span>
-                            <p class="incident-update-time">17.11.2023, 16:02 UTC</p>
-                        </div>
-                    </article>
-                </article>
-                <article>
-                    <h3>16.11.2023</h3>
-                    <p>1 incident ongoing</p>
-                </article>
-                <article>
-                    <h3>15.11.2023</h3>
-                    <p>no incidents occured</p>
-                </article>
-                <article>
-                    <h3>14.11.2023</h3>
-                    <article class="incident">
-                        <h4 class="text-maintenance"><!--<span class="incident-status status-fine">resolved</span>--><a class="text-maintenance" href="./incident.html">API 1 - Scheduled Maintenance</a></h4>
-                        <div class="incident-update">
-                            <h5>Done</h5>
-                            <span class="incident-update-content"> - Finished maintenance session. Service is back up.</span>
-                            <p class="incident-update-time">14.11.2023, 11:45 UTC</p>
-                        </div>
-                        <div class="incident-update">
-                            <h5>Started</h5>
-                            <span class="incident-update-content"> - Started the scheduled maintenance session. Return to operational state is expected in roughly two hours.</span>
-                            <p class="incident-update-time">14.11.2023, 10:00 UTC</p>
-                        </div>
-                    </article>
-                </article>
-            </section>
+            {{> incident-log }}
         </section>
     </main>
     <footer>
         <div id="accessibility-options">
             <h5>Accessibility options:</h5>
             <input id="colorBlindMode" type="checkbox" onclick="switchColorMode()"></input><label for="colorBlindMode">Colors for colorblind</label>
-            <input id="tableMode" type="checkbox" onclick="switchApiDisplay()"></input><label for="tableMode">Use table display</label>
-            <input id="tableHideFineDays" type="checkbox" onclick="switchTableHideOperationalDays()" disabled></input><label id="tableHideFineDaysLabel" class="disabled" for="tableHideFineDays">Use table display</label>
             <input id="increasedTextSizeMode" type="checkbox" onclick="switchTextSize()"></input><label for="increasedTextSizeMode">Increased text size</label>
         </div>
         <div id="other-links">


### PR DESCRIPTION
This PR adds the option to only display days with incidents when using the table display as well as a templated version of the past incidents log. It also moves the location of the display options into a secondary header, which also contains a navigation link that allows users to skip directly to the accessibility options.

This PR furthermore contains a few small tweaks to the site layout and the generator for the template example data.