### PR TITLE
bump version of ip package to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "^17.0.0",
         "@angular/router": "^17.0.0",
         "dayjs": "^1.11.10",
+        "ip": "^2.0.1",
         "ngx-cookie-service": "^17.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -8494,10 +8495,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8496,7 +8496,8 @@
     "node_modules/ip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@angular/platform-browser-dynamic": "^17.0.0",
         "@angular/router": "^17.0.0",
         "dayjs": "^1.11.10",
-        "ip": "^2.0.1",
         "ngx-cookie-service": "^17.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@angular/platform-browser-dynamic": "^17.0.0",
     "@angular/router": "^17.0.0",
     "dayjs": "^1.11.10",
-    "ip": "^2.0.1",
     "ngx-cookie-service": "^17.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser-dynamic": "^17.0.0",
     "@angular/router": "^17.0.0",
     "dayjs": "^1.11.10",
+    "ip": "^2.0.1",
     "ngx-cookie-service": "^17.0.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -32,3 +32,4 @@
     "unknownColor": "lightsteelblue",
     "useTestData": false
 }
+


### PR DESCRIPTION
Bumps the version of the `ip` package to 2.0.1, which contains a partial fix for [this security issue](https://github.com/advisories/GHSA-78xj-cgh5-2h22).

No further action should be necessary, as we use the web page inside a private address range with a reverse proxy placed before it.