### PR TITLE
fix order of config initialization not being always the right one

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,21 +4,30 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';
 import { HttpClientModule } from '@angular/common/http';
 import { Configuration } from '../external/lib/status-page-api/angular-client';
+import { AppConfigService, CONFIG_JSON } from './app-config.service';
 
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideRouter(routes),
-    importProvidersFrom(HttpClientModule),
-    {
-      provide: Configuration,
-      useFactory: () => new Configuration(
-        {
-          basePath: "http://api.test:8080",
-          
+export function buildAppConfig(jsonConfig: any): ApplicationConfig {
+  return {
+    providers: [
+      provideRouter(routes),
+      importProvidersFrom(HttpClientModule),
+      {
+        provide: CONFIG_JSON,
+        useValue: jsonConfig
+      },
+      {
+        provide: Configuration,
+        useFactory: (appConfig: AppConfigService) => {
+          return new Configuration(
+          {
+            basePath: appConfig.apiServerUrl,
+            
+          })
         },
-      ),
-      deps: [],
-      multi: false
-    }
-  ]
-};
+        deps: [AppConfigService],
+        multi: false
+      }
+    ]
+  };
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
+import { buildAppConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -11,5 +11,11 @@ dayjs.extend(timezone);
 dayjs.extend(advformat);
 dayjs.extend(utc);
 
-bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));
+fetch("/assets/config.json")
+  .then((response) => response.json())
+  .then((json) => {
+    bootstrapApplication(AppComponent, buildAppConfig(json))
+    .catch((err) => console.error(err));
+  });
+
+


### PR DESCRIPTION
We need the values from the configuration file available from the very beginning, when we set up the `Configuration` object for the OpenAPI client. However, this could create a race condition where the `AppConfigService` was initialized *after* the provider for the `Configuration` object, resulting in an empty `basePath` property.

To allay this malady, we moved the reading of the configuration file before the start of the actual application and use a custom `InjectionToken` to provide the resulting JSON object to the `AppConfigService`.