### PR TITLE
Fix status text for days without incidents being displayed wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ You will find a configuration file named `config.json` in the `src/assets` direc
             "colorblind": "#d62c13"
         }
     },
+    // Severity value used for days where no incidents occurred
+    "dayDefaultSeverity": 1,
     // Backup color in case an unmapped severity value has been found
     "unknownColor": "lightsteelblue",
     // A short text to be displayed above the components

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,9 +16,10 @@ The following table explains all settings available in the configuration file. E
 | dateFormat             | The format to use for dates displayed.                        | Format | "YYYY-MM-DD HH:mm:ss z"          |
 | longDateFormat         | Long format for dates, including day names.                   | Format | "dddd, Do MMMM YYYY, HH:mm:ss z" |
 | severities             | Maps severities to colors to use.                             | Object | see below                        |
+| dayDefaultSeverity     | Severity value used for days where no incidents occured       | Number | 1
 | unknownColor           | Color to use for unknown severity values.                     | Color  | "lightsteelblue"                 |
 | aboutText              | Short text that appears in the "About" section.               | String | empty                            |
-| maintenancePreviewDays | Number of days in the future to check for maintenance events. | number | 30                               |
+| maintenancePreviewDays | Number of days in the future to check for maintenance events. | Number | 30                               |
 
 The `severities` map contains one entry for each severity level specified in the API server. The default configuration included in the template file looks like this:
 

--- a/src/app/app-config.service.ts
+++ b/src/app/app-config.service.ts
@@ -16,6 +16,7 @@ class Config {
   dateFormat: string = "YYYY-MM-DD HH:mm:ss z";
   longDateFormat: string = "dddd, Do MMMM YYYY, HH:mm:ss z";
   severities: Map<string, Severity> = new Map();
+  dayDefaultSeverity: number = 1;
   unknownColor: string = "lightsteelblue";
   aboutText: string = "";
   maintenancePreviewDays: number = 30;
@@ -76,6 +77,10 @@ export class AppConfigService {
 
   get severities(): Map<string, Severity> {
     return this.config.severities;
+  }
+
+  get dayDefaultSeverity(): number {
+    return this.config.dayDefaultSeverity;
   }
 
   get unknownColor(): string {

--- a/src/app/data.service.ts
+++ b/src/app/data.service.ts
@@ -200,7 +200,7 @@ export class DataService {
       this.components.forEach((component, componentId) => {
         // Create daily data for each component
         for (const [day, incidents] of this.incidentsByDay) {
-          const dailyData = new DailyStatus(day);
+          const dailyData = new DailyStatus(day, this.config.dayDefaultSeverity);
           for (const incident of incidents) {
             // Check if the incident affects this component
             const affectingImpacts = incident[1].affects?.filter(c => c.reference === componentId) ?? [];
@@ -224,7 +224,7 @@ export class DataService {
     const statusList = this.componentStatusByDay.get(component);
     if (!statusList) {
       // TODO Error properly
-      console.log("Found a component with missing daily status list?");
+      console.error("Found a component with missing daily status list?");
       return;
     }
     let daysWithIncidents = 0;

--- a/src/app/management-view/management-view.component.ts
+++ b/src/app/management-view/management-view.component.ts
@@ -106,7 +106,7 @@ export class ManagementViewComponent implements OnInit{
   async ngOnInit(): Promise<void> {
     this.security.checkAuth().subscribe(async response => {
       if (!response.isAuthenticated) {
-        console.log(`Unauthenticated, potential error: ${response.errorMessage}`);
+        console.error(`Unauthenticated, potential error: ${response.errorMessage}`);
         this.router.navigate([""]);
       }
       this.userData = this.security.userData;

--- a/src/app/model/daily-status.ts
+++ b/src/app/model/daily-status.ts
@@ -9,9 +9,11 @@ export class DailyStatus {
     private _topLevelIncident?: [IncidentId, Incident] = undefined;
     private _topLevelImpact?: Impact = undefined;
 
-    private _severity: number = 0;
+    // We use a severity value of 1 as default. It is returned when no incidents have been 
+    // added to this day. 
+    private _severity: number = 1;
 
-    constructor(day: ShortDayString | Dayjs) {
+    constructor(day: ShortDayString | Dayjs, defaultSeverity: number) {
         if (day instanceof dayjs) {
             this.day = day.format(SHORT_DAY_FORMAT);
         } else {

--- a/src/assets/config.json
+++ b/src/assets/config.json
@@ -32,6 +32,7 @@
             "colorblind": "#d62c13"
         }
     },
+    "dayDefaultSeverity": 1,
     "unknownColor": "lightsteelblue",
     "aboutText": "This is the status page for the SCS project. It displays incidents impacting any of the important components of this SCS stack.",
     "maintenancePreviewDays": 30

--- a/src/assets/config.tmpl.json
+++ b/src/assets/config.tmpl.json
@@ -32,6 +32,7 @@
             "colorblind": "#d62c13"
         }
     },
+    "dayDefaultSeverity": 1,
     "unknownColor": "lightsteelblue",
     "aboutText": "${STATUS_PAGE_WEB_ABOUT_TEXT}",
     "maintenancePreviewDays": ${STATUS_PAGE_WEB_MAINTENANCE_PREVIEW_DAYS}


### PR DESCRIPTION
Days without incidents where displayed with the status text "maintenance," not "operational."

This occurred due to us now using severity value 0 for the special maintenance severity value. The same value was used to initialise the property used to calculate a `DailyStatus`'s overall severity value.

We now provide a field in the config file that allows users to specify the default severity value used for days without incidents.