### PR TITLE
disable update creation while creating a new incident

### DIFF
--- a/src/app/management-view/management-view.component.html
+++ b/src/app/management-view/management-view.component.html
@@ -85,8 +85,10 @@
 </div>
 <dialog #incidentDialog id="incident-dialog">
     <span id="edited-incident-id" *ngIf="!isNewIncident()">{{ editingIncidentId }}</span>
-    <h1 *ngIf="!isNewIncident()">Editing <em>{{ this.editingIncident.displayName }}</em></h1>
-    <h1 *ngIf="isNewIncident()">Creating new Incident</h1>
+    <h1 *ngIf="!isMaintenanceEvent() && !isNewIncident()">Editing <em>{{ this.editingIncident.displayName }}</em></h1>
+    <h1 *ngIf="!isMaintenanceEvent() && isNewIncident()">Creating new Incident</h1>
+    <h1 *ngIf="isMaintenanceEvent() && isNewIncident()">Creating new Maintenance Event</h1>
+    <h1 *ngIf="isMaintenanceEvent() && !isNewIncident()">Editing <em>{{ this.editingIncident.displayName }}</em></h1>
     <form (keydown.enter)="$event.preventDefault()" (keydown.shift.enter)="$event.preventDefault()">
         <label for="inputIncidentName">Display Name</label>
         <input type="text" #inputIncidentName id="inputIncidentName" name="inputIncidentName"
@@ -134,8 +136,9 @@
                     [icon]="iconAddUpdate"></fa-icon></button>
             <button type="button" (click)="deleteImpact()" class="dangerous"><fa-icon [icon]="iconDeleteUpdate"></fa-icon></button>
         </div>
-        <label for="inputIncidentUpdate" *ngIf="!isMaintenanceEvent()">Updates</label>
-        <div class="subform" *ngIf="!isMaintenanceEvent()">
+        <p class="stretch" *ngIf="isNewIncident()">Updates can be added once the incident has been created.</p>
+        <label for="inputIncidentUpdate" *ngIf="!isMaintenanceEvent() && !isNewIncident()">Updates</label>
+        <div class="subform" *ngIf="!isMaintenanceEvent() && !isNewIncident()">
             <select
                 #inputIncidentUpdate
                 id="inputIncidentUpdate"

--- a/src/app/management-view/management-view.component.ts
+++ b/src/app/management-view/management-view.component.ts
@@ -9,9 +9,8 @@ import { Incident, IncidentService, IncidentUpdate, IncidentUpdateResponseData }
 import dayjs from 'dayjs';
 import { formatQueryDate, IncidentId } from '../model/base';
 import { SpinnerComponent } from '../spinner/spinner.component';
-import { OidcSecurityService, UserDataResult } from 'angular-auth-oidc-client';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
 import { firstValueFrom, Observable } from 'rxjs';
-import { AppConfigService } from '../app-config.service';
 
 const DT_FORMAT = "YYYY-MM-DDTHH:mm";
 
@@ -92,12 +91,9 @@ export class ManagementViewComponent implements OnInit{
   @ViewChild("waitSpinnerDialog")
   private waitSpinnerDialog!: ElementRef<HTMLDialogElement>;
 
-  private userData!: Signal<UserDataResult>;
-
   constructor(
     public data: DataService,
     public util: UtilService,
-    private config: AppConfigService,
     private security: OidcSecurityService,
     private router: Router,
     private incidentService: IncidentService
@@ -109,7 +105,6 @@ export class ManagementViewComponent implements OnInit{
         console.log(`Unauthenticated, potential error: ${response.errorMessage}`);
         this.router.navigate([""]);
       }
-      this.userData = this.security.userData;
       const token = await firstValueFrom(this.security.getAccessToken());
       this.incidentService.configuration.withCredentials = true;
       this.incidentService.defaultHeaders = this.incidentService.defaultHeaders.set("Authorization", `Bearer ${token}`);


### PR DESCRIPTION
Until now, it was possible to create incident updates when creating a new incident. This leads to requests running into errors because the updates are sent to the API server before the new incident. Due to this, there is not yet an incident ID to assign these updates to and the API server responds with an error.

A proper fix would be to rewrite the code that handles the update and incident creation, but this is better done once the overall management page has been cleaned up. Therefore, for now, we just disable the fields needed to create updates when creating a new incident.